### PR TITLE
fix(ci): use requirements.txt for test workflows

### DIFF
--- a/.github/workflows/test-1-vision-violation.yml
+++ b/.github/workflows/test-1-vision-violation.yml
@@ -24,7 +24,7 @@ jobs:
       
       - name: Install dependencies
         run: |
-          pip install psycopg2-binary pinecone-client anthropic pyyaml
+          pip install -r waooaw/requirements.txt
       
       - name: Create Python file (violates Phase 1 rule)
         run: |

--- a/.github/workflows/test-2-vision-approval.yml
+++ b/.github/workflows/test-2-vision-approval.yml
@@ -24,7 +24,7 @@ jobs:
       
       - name: Install dependencies
         run: |
-          pip install psycopg2-binary pinecone-client anthropic pyyaml
+          pip install -r waooaw/requirements.txt
       
       - name: Create Markdown file (allowed in Phase 1)
         run: |

--- a/.github/workflows/test-3-memory-persistence.yml
+++ b/.github/workflows/test-3-memory-persistence.yml
@@ -19,7 +19,7 @@ jobs:
       
       - name: Install dependencies
         run: |
-          pip install psycopg2-binary pinecone-client anthropic pyyaml
+          pip install -r waooaw/requirements.txt
       
       - name: Wake Cycle 1 - Save Context
         env:


### PR DESCRIPTION
## Summary
Replace hardcoded pip install commands with requirements.txt in test workflow files.

## Changes
- Updated test-1-vision-violation.yml
- Updated test-2-vision-approval.yml
- Updated test-3-memory-persistence.yml

All three workflows now use `pip install -r waooaw/requirements.txt` instead of hardcoded `pip install psycopg2-binary pinecone-client anthropic pyyaml`.

## Benefits
✅ Consistent dependency versions across workflows and local development
✅ Easier maintenance - update requirements.txt once instead of multiple workflow files
✅ Automatically includes all required dependencies (e.g., PyGithub, python-dotenv)

## Testing
The workflows should continue to run successfully with the full set of dependencies from requirements.txt.