### PR TITLE
fix: Add PLANT_DB_PASSWORD to workflow Terraform steps

### DIFF
--- a/.github/workflows/waooaw-deploy.yml
+++ b/.github/workflows/waooaw-deploy.yml
@@ -270,6 +270,8 @@ jobs:
       - name: Plan Plant stack
         if: needs.detect.outputs.has_plant == 'true'
         working-directory: cloud/terraform/stacks/plant
+        env:
+          TF_VAR_database_password: ${{ secrets.PLANT_DB_PASSWORD }}
         run: |
           set -euo pipefail
           ENV="${{ inputs.environment }}"
@@ -373,6 +375,8 @@ jobs:
       - name: Apply Plant stack
         if: needs.detect.outputs.has_plant == 'true'
         working-directory: cloud/terraform/stacks/plant
+        env:
+          TF_VAR_database_password: ${{ secrets.PLANT_DB_PASSWORD }}
         run: |
           set -euo pipefail
           ENV="${{ inputs.environment }}"


### PR DESCRIPTION
## Problem
Terraform plan/apply was stuck waiting for `database_password` input because the workflow didn't pass the secret.

## Solution
Added `TF_VAR_database_password` environment variable to both:
- Plan Plant stack step
- Apply Plant stack step

Reads from `secrets.PLANT_DB_PASSWORD` which should be set in GitHub environment.

## Testing
After merge, re-run the WAOOAW Deploy workflow with Plant component.