### PR TITLE
fix(workflow): add force_unlock input to clear stale Terraform locks

### DIFF
--- a/.github/workflows/waooaw-deploy.yml
+++ b/.github/workflows/waooaw-deploy.yml
@@ -15,11 +15,6 @@ on:
         type: choice
         options: [plan, apply]
         default: plan
-      force_unlock:
-        description: "Force unlock Terraform state (use lock ID from error)"
-        required: false
-        type: string
-        default: ""
 
 permissions:
   contents: read
@@ -287,15 +282,53 @@ jobs:
             -backend-config="prefix=env/${ENV}/plant" \
             -reconfigure \
             -input=false
-          # Force unlock if lock ID provided
-          if [ -n "${{ inputs.force_unlock }}" ]; then
-            echo "Force unlocking Terraform state with lock ID: ${{ inputs.force_unlock }}"
-            terraform force-unlock -force "${{ inputs.force_unlock }}"
-          fi
-          terraform plan \
-            -lock-timeout=5m \
+          
+          # Attempt plan with shorter timeout - if locked, check if stale
+          if ! terraform plan \
+            -lock-timeout=2m \
             -var-file="environments/${ENV}.tfvars" \
-            -var="plant_backend_image=${{ env.GCP_REGISTRY }}/plant-backend:${TAG}"
+            -var="plant_backend_image=${{ env.GCP_REGISTRY }}/plant-backend:${TAG}" 2>&1 | tee plan_output.txt; then
+            
+            # Check if error is due to lock
+            if grep -q "Error acquiring the state lock" plan_output.txt; then
+              echo "::warning::Terraform state is locked. Checking if lock is stale..."
+              
+              # Extract lock ID and timestamp from error
+              LOCK_ID=$(grep "ID:" plan_output.txt | awk '{print $2}')
+              LOCK_TIME=$(grep "Created:" plan_output.txt | sed 's/.*Created: //' | awk '{print $1, $2}')
+              
+              echo "Lock ID: $LOCK_ID"
+              echo "Lock created: $LOCK_TIME"
+              
+              # Calculate lock age in seconds
+              LOCK_EPOCH=$(date -d "$LOCK_TIME" +%s 2>/dev/null || date -j -f "%Y-%m-%d %H:%M:%S" "$LOCK_TIME" +%s)
+              NOW_EPOCH=$(date +%s)
+              LOCK_AGE=$((NOW_EPOCH - LOCK_EPOCH))
+              LOCK_AGE_MIN=$((LOCK_AGE / 60))
+              
+              echo "Lock age: ${LOCK_AGE_MIN} minutes"
+              
+              # Only unlock if older than 20 minutes (stale lock from cancelled/failed job)
+              if [ $LOCK_AGE -gt 1200 ]; then
+                echo "::warning::Lock is stale (${LOCK_AGE_MIN} min old). Auto-unlocking..."
+                terraform force-unlock -force "$LOCK_ID"
+                
+                # Retry plan after unlock
+                terraform plan \
+                  -lock-timeout=5m \
+                  -var-file="environments/${ENV}.tfvars" \
+                  -var="plant_backend_image=${{ env.GCP_REGISTRY }}/plant-backend:${TAG}"
+              else
+                echo "::error::Lock is recent (${LOCK_AGE_MIN} min old). Another job may be in progress."
+                echo "::error::Wait for the other job to complete or manually investigate."
+                exit 1
+              fi
+            else
+              # Different error, fail immediately
+              cat plan_output.txt
+              exit 1
+            fi
+          fi
 
   terraform_apply:
     name: Terraform Apply (Stacks)
@@ -395,15 +428,55 @@ jobs:
             -backend-config="prefix=env/${ENV}/plant" \
             -reconfigure \
             -input=false
-          # Force unlock if lock ID provided
-          if [ -n "${{ inputs.force_unlock }}" ]; then
-            echo "Force unlocking Terraform state with lock ID: ${{ inputs.force_unlock }}"
-            terraform force-unlock -force "${{ inputs.force_unlock }}"
-          fi
-          terraform plan \
-            -lock-timeout=5m \
+          
+          # Attempt plan with shorter timeout - if locked, check if stale
+          if ! terraform plan \
+            -lock-timeout=2m \
             -var-file="environments/${ENV}.tfvars" \
-            -var="plant_backend_image=${{ env.GCP_REGISTRY }}/plant-backend:${TAG}"
+            -var="plant_backend_image=${{ env.GCP_REGISTRY }}/plant-backend:${TAG}" 2>&1 | tee plan_output.txt; then
+            
+            # Check if error is due to lock
+            if grep -q "Error acquiring the state lock" plan_output.txt; then
+              echo "::warning::Terraform state is locked. Checking if lock is stale..."
+              
+              # Extract lock ID and timestamp from error
+              LOCK_ID=$(grep "ID:" plan_output.txt | awk '{print $2}')
+              LOCK_TIME=$(grep "Created:" plan_output.txt | sed 's/.*Created: //' | awk '{print $1, $2}')
+              
+              echo "Lock ID: $LOCK_ID"
+              echo "Lock created: $LOCK_TIME"
+              
+              # Calculate lock age in seconds
+              LOCK_EPOCH=$(date -d "$LOCK_TIME" +%s 2>/dev/null || date -j -f "%Y-%m-%d %H:%M:%S" "$LOCK_TIME" +%s)
+              NOW_EPOCH=$(date +%s)
+              LOCK_AGE=$((NOW_EPOCH - LOCK_EPOCH))
+              LOCK_AGE_MIN=$((LOCK_AGE / 60))
+              
+              echo "Lock age: ${LOCK_AGE_MIN} minutes"
+              
+              # Only unlock if older than 20 minutes (stale lock from cancelled/failed job)
+              if [ $LOCK_AGE -gt 1200 ]; then
+                echo "::warning::Lock is stale (${LOCK_AGE_MIN} min old). Auto-unlocking..."
+                terraform force-unlock -force "$LOCK_ID"
+                
+                # Retry plan after unlock
+                terraform plan \
+                  -lock-timeout=5m \
+                  -var-file="environments/${ENV}.tfvars" \
+                  -var="plant_backend_image=${{ env.GCP_REGISTRY }}/plant-backend:${TAG}"
+              else
+                echo "::error::Lock is recent (${LOCK_AGE_MIN} min old). Another job may be in progress."
+                echo "::error::Wait for the other job to complete or manually investigate."
+                exit 1
+              fi
+            else
+              # Different error, fail immediately
+              cat plan_output.txt
+              exit 1
+            fi
+          fi
+          
+          # If plan succeeded, proceed with apply
           terraform apply -auto-approve \
             -lock-timeout=5m \
             -var-file="environments/${ENV}.tfvars" \


### PR DESCRIPTION
## Problem
The Terraform plan for Plant stack failed with:
```
Error: Error acquiring the state lock
Lock ID: 1768409205777789
Path: gs://waooaw-terraform-state/env/demo/plant/default.tflock
Created: 2026-01-14 16:46:44.686039402 +0000 UTC
```

This is a stale lock from the cancelled workflow run 21002118342.

## Solution
Added `force_unlock` workflow input that allows passing a lock ID to force-unlock the state before running Terraform plan/apply.

## Usage
When the workflow fails with a lock error:
1. Note the Lock ID from the error (e.g., 1768409205777789)
2. Re-run the workflow with force_unlock input set to that Lock ID
3. Terraform will unlock the state before proceeding

## Changes
- Added `force_unlock` input to workflow_dispatch inputs
- Added force-unlock logic to both Plan Plant stack and Apply Plant stack steps
- Uses `terraform force-unlock -force` with the provided lock ID