### PR TITLE
fix(cp-frontend): comment out /api proxy for Cloud Run deployment

### DIFF
--- a/src/CP/FrontEnd/nginx.conf
+++ b/src/CP/FrontEnd/nginx.conf
@@ -29,18 +29,18 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
-    # API proxy (if needed)
-    location /api {
-        proxy_pass http://backend:8000;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_cache_bypass $http_upgrade;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
+    # API proxy disabled for Cloud Run - API calls go through load balancer
+    # location /api {
+    #     proxy_pass http://backend:8000;
+    #     proxy_http_version 1.1;
+    #     proxy_set_header Upgrade $http_upgrade;
+    #     proxy_set_header Connection 'upgrade';
+    #     proxy_set_header Host $host;
+    #     proxy_cache_bypass $http_upgrade;
+    #     proxy_set_header X-Real-IP $remote_addr;
+    #     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    #     proxy_set_header X-Forwarded-Proto $scheme;
+    # }
 
     # Health check endpoint
     location /health {


### PR DESCRIPTION
## Problem
CP frontend fails to start in Cloud Run with nginx error:
```
nginx: [emerg] host not found in upstream "backend" in /etc/nginx/conf.d/default.conf:34
```

## Root Cause
The nginx config tries to proxy `/api` requests to `http://backend:8000`, but in Cloud Run deployment there is no "backend" container/host. API calls are routed through the load balancer instead.

## Solution
Comment out the `/api` proxy location block - same fix that was already applied to PP frontend.

## Changes
- Commented out lines 33-44 in `src/CP/FrontEnd/nginx.conf`
- Added comment explaining API calls go through load balancer in Cloud Run
- Matches PP frontend configuration

## Testing
- CI will rebuild CP frontend image with fixed nginx config
- Deploy will succeed without nginx startup errors
- API calls will route correctly through load balancer

## Related
- Same issue was fixed for PP in earlier deployment
- No backend container exists in Cloud Run - frontend and backend are separate services