### PR TITLE
fix(plant): add asyncpg and greenlet for async SQLAlchemy

### DIFF
--- a/src/Plant/BackEnd/requirements.txt
+++ b/src/Plant/BackEnd/requirements.txt
@@ -14,7 +14,9 @@ python-multipart==0.0.6
 
 # Database + ORM
 sqlalchemy==2.0.25
+asyncpg==0.29.0
 psycopg2-binary==2.9.9
+greenlet==3.0.3
 alembic==1.13.1
 pgvector==0.2.4
 


### PR DESCRIPTION
## Problem
Cloud Run container crashes with:
```
ModuleNotFoundError: No module named 'asyncpg'
```

Application fails during database initialization at startup.

## Root Cause
- SQLAlchemy 2.0 async engine configured with `postgresql+asyncpg://` dialect
- `asyncpg` package missing from requirements.txt (async PostgreSQL driver)
- `greenlet` missing (required by SQLAlchemy for async context switching)
- Code uses `create_async_engine()` but driver not installed

## Evidence
From [core/config.py](https://github.com/dlai-sd/WAOOAW/blob/main/src/Plant/BackEnd/core/config.py):
```python
database_url: str = "postgresql+asyncpg://user:password@localhost/plant"
```

From logs:
```
File "sqlalchemy/dialects/postgresql/asyncpg.py", line 1079
return AsyncAdapt_asyncpg_dbapi(__import__("asyncpg"))
ModuleNotFoundError: No module named 'asyncpg'
```

## Solution
Added two required packages:
1. **asyncpg==0.29.0** - Async PostgreSQL database driver for SQLAlchemy
2. **greenlet==3.0.3** - Required by SQLAlchemy 2.0 for async context management

## Testing
After merge:
- Workflow rebuilds Plant image with asyncpg + greenlet
- Container starts successfully
- SQLAlchemy async engine initializes
- Database connection established

## Impact
- ✅ Fixes Plant backend Cloud Run startup failure
- ✅ Enables async database operations
- ✅ No breaking changes
- ✅ Standard SQLAlchemy 2.0 async dependencies

Fixes workflow run #25