### PR TITLE
fix(cloud-run): Use annotation for Cloud SQL Proxy instead of volumes

### DIFF
--- a/cloud/terraform/modules/cloud-run/main.tf
+++ b/cloud/terraform/modules/cloud-run/main.tf
@@ -15,6 +15,11 @@ resource "google_cloud_run_v2_service" "service" {
       max_instance_count = var.max_instances
     }
 
+    # Cloud SQL Proxy annotation
+    annotations = var.cloud_sql_connection_name != null ? {
+      "run.googleapis.com/cloudsql-instances" = var.cloud_sql_connection_name
+    } : {}
+
     containers {
       image = var.image
 
@@ -54,15 +59,6 @@ resource "google_cloud_run_v2_service" "service" {
         }
       }
 
-      # Cloud SQL Proxy integration
-      dynamic "volume_mounts" {
-        for_each = var.cloud_sql_connection_name != null ? [1] : []
-        content {
-          name       = "cloudsql"
-          mount_path = "/cloudsql"
-        }
-      }
-
       # Startup probe for services with database initialization
       dynamic "startup_probe" {
         for_each = var.cloud_sql_connection_name != null ? [1] : []
@@ -74,16 +70,6 @@ resource "google_cloud_run_v2_service" "service" {
           tcp_socket {
             port = var.port
           }
-        }
-      }
-    }
-
-    dynamic "volumes" {
-      for_each = var.cloud_sql_connection_name != null ? [var.cloud_sql_connection_name] : []
-      content {
-        name = "cloudsql"
-        cloud_sql_instance {
-          instances = [volumes.value]
         }
       }
     }


### PR DESCRIPTION
## Root Cause
Volumes and volume_mounts don't create Cloud SQL Proxy connection in Cloud Run v2. The annotation exists but proxy isn't injected.

## Evidence
Deployed service shows:
```yaml
annotations:
  run.googleapis.com/cloudsql-instances: waooaw-oauth:asia-south1:plant-sql-demo
```

But no actual /cloudsql/ socket - container gets TimeoutError trying to connect.

## Fix
Remove volume blocks, use **template annotations** instead:
```hcl
template {
  annotations = var.cloud_sql_connection_name != null ? {
    "run.googleapis.com/cloudsql-instances" = var.cloud_sql_connection_name
  } : {}
  ...
}
```

This is the correct Cloud Run v2 API method for Cloud SQL Proxy injection.

## Testing
- Terraform validates successfully
- Matches deployed service annotation pattern  
- Should enable /cloudsql/ Unix socket access

Fixes Plant backend database connectivity.