### PR TITLE
fix(plant): Handle existing pgvector extension gracefully

### DIFF
--- a/src/Plant/BackEnd/core/database.py
+++ b/src/Plant/BackEnd/core/database.py
@@ -93,11 +93,18 @@ class DatabaseConnector:
     async def _setup_extensions(self):
         """Load PostgreSQL extensions on connection."""
         async with self.engine.begin() as conn:
-            # Enable pgvector extension (vector similarity search)
-            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector;"))
+            try:
+                # Enable pgvector extension (vector similarity search)
+                await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector;"))
+            except Exception as e:
+                # Extension might already exist from previous deployment
+                logger.warning(f"pgvector extension setup: {str(e)}")
             
-            # Enable uuid-ossp extension (UUID generation)
-            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";"))
+            try:
+                # Enable uuid-ossp extension (UUID generation)
+                await conn.execute(text("CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";"))
+            except Exception as e:
+                logger.warning(f"uuid-ossp extension setup: {str(e)}")
             
             # Set default search path
             await conn.execute(text("SET search_path TO public;"))


### PR DESCRIPTION
## Problem
Plant backend startup was failing with IntegrityError:
```
duplicate key value violates unique constraint "pg_extension_name_index"
```

## Root Cause
The `_setup_extensions()` method tries to create pgvector and uuid-ossp extensions on every startup. When these extensions already exist from previous deployments, PostgreSQL raises an IntegrityError even though we use `CREATE EXTENSION IF NOT EXISTS`.

## Solution
Wrapped extension creation in try-except blocks to log warnings instead of crashing:
- pgvector extension: Log warning if already exists
- uuid-ossp extension: Log warning if already exists
- search_path: Still executed (no side effects)

## Testing
- **VPC Connector:** ✅ READY (10.8.0.0/28)
- **Cloud Run:** ✅ Deployed (waooaw-plant-backend-demo-00001-p74)
- **Current Status:** Startup fails on extension setup
- **After Fix:** Should start successfully and connect to Cloud SQL

## Deployment
After merge, trigger WAOOAW Deploy workflow:
- Environment: demo
- Action: apply