### PR TITLE
feat(foundation): Enable Plant backend in demo load balancer

### DIFF
--- a/cloud/terraform/stacks/foundation/environments/default.tfvars
+++ b/cloud/terraform/stacks/foundation/environments/default.tfvars
@@ -5,7 +5,7 @@ static_ip_name = "waooaw-lb-ip"
 # Toggle-on when PP/Plant stacks exist and are ready to route.
 enable_cp    = true
 enable_pp    = true
-enable_plant = false
+enable_plant = true
 
 # Bootstrap with demo-only first. Add uat/prod once their app stacks have been applied.
 enabled_environments = ["demo"]


### PR DESCRIPTION
## Summary
Enable Plant backend integration into shared load balancer for demo environment.

## Changes
- Set `enable_plant = true` in foundation default.tfvars

## Impact
- **New SSL certificate**: waooaw-shared-ssl-c5a2c62d (replacing 779b788b)
- **Domains**: cp.demo.waooaw.com, pp.demo.waooaw.com, plant.demo.waooaw.com
- **Load balancer**: Adds host rule plant.demo.waooaw.com → plant_backend
- **Backend service**: shared-plant-demo-backend-backend (with NEG waooaw-demo-plant-backend-neg)
- **Health check**: demo-plant-backend-health
- **Zero downtime**: create_before_destroy lifecycle ensures CP/PP unaffected

## SSL Certificate Transition
```
Current: waooaw-shared-ssl-779b788b (CP + PP)
     ↓
New: waooaw-shared-ssl-c5a2c62d (CP + PP + Plant) ← created first
     ↓
Proxy switches atomically when new cert ACTIVE
     ↓
Old cert destroyed: 779b788b
```

## Testing After Foundation Workflow
- [ ] Verify new SSL cert ACTIVE: `gcloud compute ssl-certificates list`
- [ ] Test Plant health: `curl https://plant.demo.waooaw.com/health`
- [ ] Test Plant API: `curl https://plant.demo.waooaw.com/api/v1/genesis/skills`
- [ ] Regression test CP: `curl https://cp.demo.waooaw.com/health`
- [ ] Regression test PP: `curl https://pp.demo.waooaw.com/health`

## Next Steps
1. Merge PR
2. Run workflow: **WAOOAW Deploy - Foundation (Shared LB)** with `terraform_action = apply`
3. Wait 15-60 min for SSL certificate provisioning
4. Verify plant.demo.waooaw.com accessible