### PR TITLE
fix(deploy): health check uses GET instead of HEAD

### DIFF
--- a/.github/workflows/waooaw-deploy.yml
+++ b/.github/workflows/waooaw-deploy.yml
@@ -498,7 +498,7 @@ jobs:
           echo "Testing CP health: $URL"
           for i in {1..10}; do
             echo "Attempt $i/10..."
-            if curl -f -s -I -m 10 "$URL" | head -1 | grep -q "200"; then
+            if curl -f -s -m 10 "$URL" | grep -q "healthy\|ok"; then
               echo "✅ CP health check passed"
               exit 0
             fi
@@ -520,7 +520,7 @@ jobs:
           echo "Testing PP health: $URL"
           for i in {1..10}; do
             echo "Attempt $i/10..."
-            if curl -f -s -I -m 10 "$URL" | head -1 | grep -q "200"; then
+            if curl -f -s -m 10 "$URL" | grep -q "healthy\|ok"; then
               echo "✅ PP health check passed"
               exit 0
             fi


### PR DESCRIPTION
## Issue
Health check validation failed during demo deployment even though Terraform apply succeeded.

**Root Cause:**
- Health endpoints return HTTP 405 for HEAD requests
- Workflow used `curl -I` which sends HEAD request
- FastAPI endpoints only support GET: `{"status":"healthy"}`

**Evidence:**
```bash
curl -I https://cp.demo.waooaw.com/health  # Returns 405 Method Not Allowed
curl https://cp.demo.waooaw.com/health     # Returns {"status":"healthy"}
```

## Solution
Changed health checks from HEAD to GET requests:
- **Before:** `curl -I | grep "200"` (check status code)
- **After:** `curl | grep "healthy|ok"` (check response body)

## Files Changed
- `.github/workflows/waooaw-deploy.yml`
  - CP health endpoint check (line 501)
  - PP health endpoint check (line 523)

## Testing
✅ Verified manually:
- CP: `curl https://cp.demo.waooaw.com/health` → `{"status":"healthy"}`
- PP: `curl https://pp.demo.waooaw.com/health` → (will test after merge)

## Impact
- **Services already deployed:** Terraform apply completed successfully
- **Only validation failed:** Health check needs retry after fix
- **Next step:** Re-run workflow with terraform_action: apply

## Related
- Previous PR: #127 (CI/CD automation - merged)
- Deployment run: 21069279615 (failed at health check)
- Commit: a668553