### PR TITLE
fix(deploy): add Plant health check GET fix

### DIFF
--- a/.github/workflows/waooaw-deploy.yml
+++ b/.github/workflows/waooaw-deploy.yml
@@ -542,7 +542,7 @@ jobs:
           echo "Testing Plant health: $URL"
           for i in {1..10}; do
             echo "Attempt $i/10..."
-            if curl -f -s -I -m 10 "$URL" | head -1 | grep -q "200"; then
+            if curl -f -s -m 10 "$URL" | grep -q "healthy\|ok"; then
               echo "✅ Plant health check passed"
               exit 0
             fi


### PR DESCRIPTION
## Critical Fix

PR #128 included fixes for CP and PP health checks but missed Plant.

**Issue:** Plant health check still uses `curl -I` (HEAD) which returns 405

**Commit:** 66fd6bd

**Fix:** Change Plant health check from HEAD to GET request

**Verified:**
```bash
curl https://plant.demo.waooaw.com/health
→ {"status":"healthy","database":"connected"}
```

**Urgency:** Current deployment (run 21070373100) will fail without this