### PR TITLE
fix(migrations): use unified GCP_SA_KEY secret

### DIFF
--- a/.github/workflows/plant-db-migrations.yml
+++ b/.github/workflows/plant-db-migrations.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY_DEMO }}
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up Cloud SQL Proxy
         run: |
@@ -154,7 +154,7 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY_UAT }}
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up Cloud SQL Proxy
         run: |
@@ -255,7 +255,7 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY_PROD }}
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up Cloud SQL Proxy
         run: |


### PR DESCRIPTION
## Issue
Database migration workflow failing with **AuthenticationFailed** error.

**Root Cause:**
- Workflow uses `secrets.GCP_SA_KEY_DEMO/UAT/PROD`
- Repository only has `secrets.GCP_SA_KEY`

## Fix
Changed all 3 environments to use `secrets.GCP_SA_KEY`:
- ✅ Demo migration
- ✅ UAT migration  
- ✅ Prod migration

Matches the pattern used in `waooaw-deploy.yml` (single service account).

## Testing
After merge, retry: **Plant Backend - Database Migrations**
- Environment: demo
- Migration type: both

## Related
- Failed run: https://github.com/dlai-sd/WAOOAW/actions/runs/21071398025
- Error: AuthenticationFailed on step 5