### PR TITLE
fix(migrations): use environment-scoped secrets

### DIFF
--- a/.github/workflows/plant-db-migrations.yml
+++ b/.github/workflows/plant-db-migrations.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O cloud_sql_proxy
           chmod +x cloud_sql_proxy
-          ./cloud_sql_proxy -instances=${{ secrets.CLOUD_SQL_CONNECTION_NAME_DEMO }}=tcp:5432 &
+          ./cloud_sql_proxy -instances=${{ secrets.CLOUD_SQL_CONNECTION_NAME }}=tcp:5432 &
           sleep 5
 
       - name: Verify Cloud SQL RUNNABLE
@@ -78,7 +78,7 @@ jobs:
       - name: Run migrations
         if: github.event.inputs.migration_type == 'upgrade' || github.event.inputs.migration_type == 'both' || github.event_name == 'push'
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_DEMO }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           cd src/Plant/BackEnd
           ./scripts/migrate-db.sh demo
@@ -86,7 +86,7 @@ jobs:
       - name: Seed Genesis data
         if: github.event.inputs.migration_type == 'seed' || github.event.inputs.migration_type == 'both'
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_DEMO }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           cd src/Plant/BackEnd
           ./scripts/seed-db.sh demo
@@ -99,7 +99,7 @@ jobs:
 
       - name: Smoke test database
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_DEMO }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           set -euo pipefail
           echo "Running database smoke tests..."
@@ -160,7 +160,7 @@ jobs:
         run: |
           wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O cloud_sql_proxy
           chmod +x cloud_sql_proxy
-          ./cloud_sql_proxy -instances=${{ secrets.CLOUD_SQL_CONNECTION_NAME_UAT }}=tcp:5432 &
+          ./cloud_sql_proxy -instances=${{ secrets.CLOUD_SQL_CONNECTION_NAME }}=tcp:5432 &
           sleep 5
 
       - name: Verify Cloud SQL RUNNABLE
@@ -180,7 +180,7 @@ jobs:
       - name: Run migrations
         if: github.event.inputs.migration_type == 'upgrade' || github.event.inputs.migration_type == 'both'
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_UAT }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           cd src/Plant/BackEnd
           ./scripts/migrate-db.sh uat
@@ -188,7 +188,7 @@ jobs:
       - name: Seed Genesis data
         if: github.event.inputs.migration_type == 'seed' || github.event.inputs.migration_type == 'both'
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_UAT }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           cd src/Plant/BackEnd
           ./scripts/seed-db.sh uat
@@ -201,7 +201,7 @@ jobs:
 
       - name: Smoke test database
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_UAT }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           set -euo pipefail
           echo "Running database smoke tests..."
@@ -261,7 +261,7 @@ jobs:
         run: |
           wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O cloud_sql_proxy
           chmod +x cloud_sql_proxy
-          ./cloud_sql_proxy -instances=${{ secrets.CLOUD_SQL_CONNECTION_NAME_PROD }}=tcp:5432 &
+          ./cloud_sql_proxy -instances=${{ secrets.CLOUD_SQL_CONNECTION_NAME }}=tcp:5432 &
           sleep 5
 
       - name: Verify Cloud SQL RUNNABLE
@@ -288,7 +288,7 @@ jobs:
       - name: Run migrations
         if: github.event.inputs.migration_type == 'upgrade' || github.event.inputs.migration_type == 'both'
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           cd src/Plant/BackEnd
           ./scripts/migrate-db.sh prod
@@ -296,7 +296,7 @@ jobs:
       - name: Seed Genesis data
         if: github.event.inputs.migration_type == 'seed' || github.event.inputs.migration_type == 'both'
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           cd src/Plant/BackEnd
           ./scripts/seed-db.sh prod
@@ -309,7 +309,7 @@ jobs:
 
       - name: Smoke test database
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL_PROD }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: |
           set -euo pipefail
           echo "Running database smoke tests..."


### PR DESCRIPTION
## Issue
Database migration failing - using wrong secret names with environment suffixes.

## Root Cause
Workflow uses repository-level secrets with `_DEMO/_UAT/_PROD` suffixes, but secrets are **environment-scoped** (defined in demo/uat/prod environments).

## Fix
Changed to use environment-scoped secret names (no suffix):
- `CLOUD_SQL_CONNECTION_NAME_DEMO` → `CLOUD_SQL_CONNECTION_NAME`
- `DATABASE_URL_DEMO` → `DATABASE_URL`
- Applied to all 3 environments (demo, uat, prod)

## Pattern
Matches `plant-db-infra.yml` which correctly uses:
```yaml
environment: ${{ inputs.environment }}
secrets.GCP_SA_KEY          # Not GCP_SA_KEY_DEMO
secrets.PLANT_DB_PASSWORD   # Not PLANT_DB_PASSWORD_DEMO
```

## Required Environment Secrets (demo)
User confirmed these exist in demo environment:
- ✅ `GCP_SA_KEY`
- ✅ `PLANT_DB_PASSWORD`
- ❓ `CLOUD_SQL_CONNECTION_NAME` (need to verify)
- ❓ `DATABASE_URL` (need to verify)

## Testing
After merge, run: **Plant Backend - Database Migrations**
- Environment: demo
- Migration type: both

## Supersedes
PR #130 (wrong approach - that used repository secret without understanding environment scoping)