### PR TITLE
fix(plant): Allow CI to use DATABASE_URL from environment

### DIFF
--- a/src/Plant/BackEnd/scripts/migrate-db.sh
+++ b/src/Plant/BackEnd/scripts/migrate-db.sh
@@ -23,19 +23,24 @@ fi
 
 echo "🚀 Starting database migration for environment: $ENVIRONMENT"
 
-# Load environment variables
-ENV_FILE=".env.$ENVIRONMENT"
-if [ ! -f "$ENV_FILE" ]; then
-  echo "❌ Error: Environment file not found: $ENV_FILE"
-  exit 1
+# Load environment variables (skip if DATABASE_URL already set in CI)
+if [ -z "$DATABASE_URL" ]; then
+  ENV_FILE=".env.$ENVIRONMENT"
+  if [ ! -f "$ENV_FILE" ]; then
+    echo "❌ Error: Environment file not found: $ENV_FILE"
+    exit 1
+  fi
+
+  set -a  # Export all variables
+  source "$ENV_FILE"
+  set +a
+
+  echo "✅ Loaded environment: $ENV_FILE"
+else
+  echo "✅ Using DATABASE_URL from environment (CI mode)"
 fi
 
-set -a  # Export all variables
-source "$ENV_FILE"
-set +a
-
-echo "✅ Loaded environment: $ENV_FILE"
-echo "   Database: $DATABASE_URL"
+echo "   Database: ${DATABASE_URL:0:50}..."  # Truncate for security
 
 # Check if Alembic is installed
 if ! command -v alembic &> /dev/null; then

--- a/src/Plant/BackEnd/scripts/seed-db.sh
+++ b/src/Plant/BackEnd/scripts/seed-db.sh
@@ -21,18 +21,22 @@ fi
 
 echo "🌱 Starting database seeding for environment: $ENVIRONMENT"
 
-# Load environment variables
-ENV_FILE=".env.$ENVIRONMENT"
-if [ ! -f "$ENV_FILE" ]; then
-  echo "❌ Error: Environment file not found: $ENV_FILE"
-  exit 1
+# Load environment variables (skip if DATABASE_URL already set in CI)
+if [ -z "$DATABASE_URL" ]; then
+  ENV_FILE=".env.$ENVIRONMENT"
+  if [ ! -f "$ENV_FILE" ]; then
+    echo "❌ Error: Environment file not found: $ENV_FILE"
+    exit 1
+  fi
+
+  set -a
+  source "$ENV_FILE"
+  set +a
+
+  echo "✅ Loaded environment: $ENV_FILE"
+else
+  echo "✅ Using DATABASE_URL from environment (CI mode)"
 fi
-
-set -a
-source "$ENV_FILE"
-set +a
-
-echo "✅ Loaded environment: $ENV_FILE"
 
 # Run seeding script
 echo "🌱 Seeding Genesis baseline data..."


### PR DESCRIPTION
## Problem

Database migration workflow was failing with:
```
❌ Error: Environment file not found: .env.demo
```

**Root cause**: Migration and seed scripts were designed for local development with `.env.*` files, but CI passes `DATABASE_URL` as an environment variable from GCP Secret Manager.

## Solution

Modified both scripts to check if `DATABASE_URL` is already set in the environment:
- If YES → Use environment variable (CI mode)
- If NO → Load from `.env.$ENVIRONMENT` file (local development)

## Changes

**src/Plant/BackEnd/scripts/migrate-db.sh:**
- Check if `DATABASE_URL` exists before requiring `.env` file
- Skip file loading in CI, preserving local workflow

**src/Plant/BackEnd/scripts/seed-db.sh:**
- Same pattern applied for consistency

## Testing

This enables both workflows:
1. **Local dev**: `./migrate-db.sh demo` (requires `.env.demo`)
2. **CI**: `DATABASE_URL=\$SECRET ./migrate-db.sh demo` (uses env var from Secret Manager)

## Related

- Fixes migration workflow failure in run #21074097678
- Enables PR #132 database pattern (fetch from Secret Manager)