### PR TITLE
Fix Cloud SQL Proxy unix socket creation

### DIFF
--- a/.github/workflows/plant-db-migrations.yml
+++ b/.github/workflows/plant-db-migrations.yml
@@ -69,9 +69,10 @@ jobs:
         run: |
           wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O cloud_sql_proxy
           chmod +x cloud_sql_proxy
-          ./cloud_sql_proxy -instances=${{ env.CONNECTION_NAME }} &
-          sleep 5
-          echo "✅ Cloud SQL Proxy started with unix socket"
+          mkdir -p /cloudsql
+          ./cloud_sql_proxy -dir=/cloudsql -instances=${{ env.CONNECTION_NAME }} &
+          sleep 10
+          echo "✅ Cloud SQL Proxy started with unix socket in /cloudsql"
 
       - name: Verify Cloud SQL RUNNABLE
         run: |
@@ -193,9 +194,10 @@ jobs:
         run: |
           wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O cloud_sql_proxy
           chmod +x cloud_sql_proxy
-          ./cloud_sql_proxy -instances=${{ env.CONNECTION_NAME }} &
-          sleep 5
-          echo "✅ Cloud SQL Proxy started with unix socket"
+          mkdir -p /cloudsql
+          ./cloud_sql_proxy -dir=/cloudsql -instances=${{ env.CONNECTION_NAME }} &
+          sleep 10
+          echo "✅ Cloud SQL Proxy started with unix socket in /cloudsql"
 
       - name: Verify Cloud SQL RUNNABLE
         run: |
@@ -316,9 +318,10 @@ jobs:
         run: |
           wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O cloud_sql_proxy
           chmod +x cloud_sql_proxy
-          ./cloud_sql_proxy -instances=${{ env.CONNECTION_NAME }} &
-          sleep 5
-          echo "✅ Cloud SQL Proxy started with unix socket"
+          mkdir -p /cloudsql
+          ./cloud_sql_proxy -dir=/cloudsql -instances=${{ env.CONNECTION_NAME }} &
+          sleep 10
+          echo "✅ Cloud SQL Proxy started with unix socket in /cloudsql"
 
       - name: Verify Cloud SQL RUNNABLE
         run: |


### PR DESCRIPTION
## Problem

The Cloud SQL Proxy was failing silently with error:
```
2026/01/16 17:12:48 must set -dir: using a unix socket for waooaw-oauth:asia-south1:plant-sql-demo
```

This caused migrations to fail because the unix socket file was never created at `/cloudsql/PROJECT:REGION:INSTANCE/.s.PGSQL.5432`.

## Root Cause

Cloud SQL Proxy v1 **requires the `-dir` flag** when operating in unix socket mode. Without it, the proxy cannot create the socket file.

## Solution

✅ Add `mkdir -p /cloudsql` to create socket directory
✅ Add `-dir=/cloudsql` flag to proxy command  
✅ Apply fix to **all 3 jobs** (migrate-demo, migrate-uat, migrate-prod)
✅ Increase sleep from 5s → 10s for proper initialization
✅ Update success message to confirm socket location

## Testing

After this fix, the proxy will:
1. Create `/cloudsql` directory
2. Start proxy with unix socket at `/cloudsql/PROJECT:REGION:INSTANCE/.s.PGSQL.5432`
3. Allow Alembic to connect using `DATABASE_URL` with `host=/cloudsql/...`

## References

- Failed workflow run: [21074654676](https://github.com/dlai-sd/WAOOAW/actions/runs/21074654676)
- Cloud SQL Proxy docs: https://cloud.google.com/sql/docs/postgres/connect-run#proxy
- Related: PR #134 (DATABASE_URL from Secret Manager)
