### PR TITLE
Fix Cloud SQL Proxy permission denied

### DIFF
--- a/.github/workflows/plant-db-migrations.yml
+++ b/.github/workflows/plant-db-migrations.yml
@@ -69,7 +69,8 @@ jobs:
         run: |
           wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O cloud_sql_proxy
           chmod +x cloud_sql_proxy
-          mkdir -p /cloudsql
+          sudo mkdir -p /cloudsql
+          sudo chmod 777 /cloudsql
           ./cloud_sql_proxy -dir=/cloudsql -instances=${{ env.CONNECTION_NAME }} &
           sleep 10
           echo "✅ Cloud SQL Proxy started with unix socket in /cloudsql"
@@ -194,7 +195,8 @@ jobs:
         run: |
           wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O cloud_sql_proxy
           chmod +x cloud_sql_proxy
-          mkdir -p /cloudsql
+          sudo mkdir -p /cloudsql
+          sudo chmod 777 /cloudsql
           ./cloud_sql_proxy -dir=/cloudsql -instances=${{ env.CONNECTION_NAME }} &
           sleep 10
           echo "✅ Cloud SQL Proxy started with unix socket in /cloudsql"
@@ -318,7 +320,8 @@ jobs:
         run: |
           wget https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O cloud_sql_proxy
           chmod +x cloud_sql_proxy
-          mkdir -p /cloudsql
+          sudo mkdir -p /cloudsql
+          sudo chmod 777 /cloudsql
           ./cloud_sql_proxy -dir=/cloudsql -instances=${{ env.CONNECTION_NAME }} &
           sleep 10
           echo "✅ Cloud SQL Proxy started with unix socket in /cloudsql"


### PR DESCRIPTION
## Problem
Previous run failed with:
```
mkdir: cannot create directory '/cloudsql': Permission denied
```

GitHub Actions runners run as non-root user and cannot create directories at root level without sudo.

## Solution
- Add `sudo mkdir -p /cloudsql`
- Add `sudo chmod 777 /cloudsql` for write permissions
- Applied to all 3 jobs (demo, uat, prod)

## Testing
GitHub Actions runners have sudo access, this will work in CI environment.

## References
- Failed run: 21074981876
- Related: PR #136 (added -dir flag)