### PR TITLE
fix(terraform): ignore image changes in cloud-run module

### DIFF
--- a/cloud/terraform/modules/cloud-run/main.tf
+++ b/cloud/terraform/modules/cloud-run/main.tf
@@ -90,6 +90,12 @@ resource "google_cloud_run_v2_service" "service" {
     type    = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
     percent = 100
   }
+
+  lifecycle {
+    ignore_changes = [
+      template[0].containers[0].image,
+    ]
+  }
 }
 
 # Allow unauthenticated access


### PR DESCRIPTION
Fixes Terraform error when reconciling state: Cloud Run service was trying to update with non-existent image tag.

Added lifecycle block to ignore image changes in cloud-run module, matching the pattern already used in cloud-run-job module.

This allows Terraform to manage Cloud Run services without requiring the Docker image to exist.