### PR TITLE
fix(terraform): Enable image updates by removing template from ignore_changes

### DIFF
--- a/cloud/terraform/modules/cloud-run/main.tf
+++ b/cloud/terraform/modules/cloud-run/main.tf
@@ -94,7 +94,6 @@ resource "google_cloud_run_v2_service" "service" {
   lifecycle {
     create_before_destroy = false
     ignore_changes = [
-      template, # Ignore entire template block to prevent modifications
       labels,
       annotations
     ]


### PR DESCRIPTION
## Problem
OAuth login broken on cp.demo.waooaw.com and pp.demo.waooaw.com due to missing GOOGLE_CLIENT_ID.

## Root Cause
Cloud Run terraform module had `lifecycle.ignore_changes = [template]` which **blocked ALL image updates** from CI/CD pipeline.

When workflow built new Docker images with GOOGLE_OAUTH_CLIENT_ID and passed new tags via `-var` flags, terraform reported "0 changed" and never updated Cloud Run services.

## Solution
Remove `template` from `ignore_changes` block while keeping `labels` and `annotations` ignored.

## Impact
- ✅ CP frontend: Will now get OAuth fix
- ✅ PP frontend: Will now get OAuth fix
- ✅ All services: CI/CD image updates will work again

## Testing
After merge, trigger workflow on main branch - terraform should show "X changed" and update services with new images.