### PR TITLE
fix(plant): Change backend port from 8001 to 8000 to match Cloud Run

### DIFF
--- a/src/Plant/BackEnd/Dockerfile
+++ b/src/Plant/BackEnd/Dockerfile
@@ -45,23 +45,24 @@ COPY --chown=appuser:appuser . .
 # Switch to non-root user
 USER appuser
 
-# Health check
+# Health check (use PORT env var with default 8000)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD curl -f http://localhost:8001/health || exit 1
+    CMD curl -f http://localhost:${PORT:-8000}/health || exit 1
 
-# Expose port (Plant Backend runs on 8001, Gateway on 8000)
-EXPOSE 8001
+# Expose port (Cloud Run provides PORT env var, default 8000)
+EXPOSE 8000
 
 # Environment variables (can be overridden by Cloud Run)
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     LOG_LEVEL=info \
-    WORKERS=4
+    WORKERS=4 \
+    PORT=8000
 
-# Start application
+# Start application (use PORT env var from Cloud Run)
 CMD exec uvicorn main:app \
     --host 0.0.0.0 \
-    --port 8001 \
+    --port ${PORT} \
     --workers ${WORKERS} \
     --loop uvloop \
     --http httptools \


### PR DESCRIPTION
## Problem
Plant backend deployment failed with:
```
Error code 9: The user-provided container failed to start and listen 
on the port defined by the PORT=8000 environment variable
```

## Root Cause
**Port Mismatch:**
- Dockerfile hardcoded: `EXPOSE 8001` and `--port 8001`
- Terraform configured: `port = 8000`
- Cloud Run sets: `PORT=8000`

Container started successfully on port 8001, but Cloud Run health checks expected port 8000, causing timeout failure.

## Solution
- Use `PORT` environment variable (default 8000) in Dockerfile
- Align with CP/PP backend convention (all use port 8000)
- Make healthcheck use `${PORT}` variable

## Changes
- `EXPOSE 8000` (was 8001)
- `--port ${PORT}` (was --port 8001)
- Healthcheck uses `${PORT:-8000}`

## Impact
✅ Plant backend deployment will succeed
✅ Consistent port convention across all services (CP/PP/Plant)