### PR TITLE
fix(alm): detect Coding completion reliably

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1694,26 +1694,37 @@ jobs:
         with:
           script: |
             const epicNumber = '${{ needs.trigger-coding-agent.outputs.epic_number }}';
-            const maxAttempts = 12; // 60 seconds total (12 × 5s)
+            const maxAttempts = 24; // 2 minutes total (24 × 5s)
             const pollInterval = 5000; // 5 seconds
 
+            const completionHeader = '## 🤖 Coding Agent - Phase 7/7';
+            const completionMarker = 'Implementation Complete';
+
             core.info('Polling for Coding Agent completion...');
+
+            let since = null;
 
             for (let attempt = 1; attempt <= maxAttempts; attempt++) {
               core.info(`Polling attempt ${attempt}/${maxAttempts}...`);
 
-              // Fetch recent comments on epic
-              const comments = await github.rest.issues.listComments({
+              const params = {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: epicNumber,
-                per_page: 20 // Last 20 comments should include Phase 7
-              });
+                per_page: 100
+              };
 
-              // Check if Coding Agent posted final phase
-              const finalPhase = comments.data.find(c =>
-                c.body.includes('## 🤖 Coding Agent - Phase 7/7') &&
-                c.body.includes('Implementation Complete')
+              if (since) {
+                params.since = since;
+              }
+
+              // Note: GitHub returns issue comments oldest-first. We paginate to ensure we can
+              // detect Phase 7/7 even if the epic has lots of comments.
+              const comments = await github.paginate(github.rest.issues.listComments, params);
+
+              const finalPhase = comments.find(c =>
+                c.body.includes(completionHeader) &&
+                c.body.includes(completionMarker)
               );
 
               if (finalPhase) {
@@ -1721,6 +1732,10 @@ jobs:
                 core.setOutput('epic_number', epicNumber);
                 return; // Exit successfully
               }
+
+              // After the first full scan, only request newer comments on subsequent polls.
+              // Use a small lookback buffer to avoid clock skew / race conditions.
+              since = new Date(Date.now() - 60_000).toISOString();
 
               // Wait before next poll (except on last attempt)
               if (attempt < maxAttempts) {
@@ -1730,10 +1745,8 @@ jobs:
             }
 
             // Timeout reached
-            core.error('❌ Coding Agent did not complete within 60 seconds');
-            throw new Error('Timeout: Coding Agent Phase 7/7 not detected after 60s. Check if Coding Agent job failed.');
-
-            core.setOutput('epic_number', epicNumber);
+            core.error('❌ Coding Agent did not complete within allotted time');
+            throw new Error('Timeout: Coding Agent Phase 7/7 not detected. Check if Coding Agent job failed or is still running.');
 
       - name: Invoke Testing Agent
         uses: actions/github-script@v7


### PR DESCRIPTION
Fixes a flaky failure where Testing timed out because issue comments are returned oldest-first and only the first 20 were scanned.

- Paginate comments when polling for Coding Agent Phase 7/7 completion
- Then poll only newer comments via the GitHub API 'since' parameter (with a small lookback buffer)
- Extend poll window to 2 minutes to reduce race-condition flakes

This unblocks epics where Coding completes but Testing never sees the completion marker.