### PR TITLE
fix(code-agent): Trigger on story creation (opened event)

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -22,7 +22,7 @@ jobs:
       issues: write
     if: |
       github.event_name == 'issues' &&
-      github.event.action == 'labeled' &&
+      (github.event.action == 'labeled' || github.event.action == 'opened') &&
       contains(github.event.issue.labels.*.name, 'code-agent') &&
       contains(github.event.issue.labels.*.name, 'user-story')
     steps:


### PR DESCRIPTION
## Fix

Code Agent now triggers on:
- `issues.opened` - when BA creates stories with `code-agent` label
- `issues.labeled` - when label added manually

## Problem
Stories created by BA with labels already attached never triggered Code Agent.

## Change
```yaml
- github.event.action == 'labeled'
+ (github.event.action == 'labeled' || github.event.action == 'opened')
```

## Testing
Epic #234 stories #235-240 have `code-agent` label but never triggered. After merge, new story creation will auto-trigger Code Agent.