### PR TITLE
fix(code-agent): Use MODELS_TOKEN for GitHub Models API

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Run Code Agent
         id: run_code_agent
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_MODELS_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MODELS_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           python scripts/code_agent.py \
             --epic-number "${{ steps.resolve.outputs.epic_number }}" \


### PR DESCRIPTION
**Root Cause**: Code Agent failed with 401 Unauthorized because `secrets.GITHUB_TOKEN` (Actions auto-token) doesn't have GitHub Models API access.

**Solution**: Use `secrets.MODELS_TOKEN` (PAT with Models access) with fallback to `GITHUB_TOKEN`.

**Changes**:
- Updated workflow to use `secrets.MODELS_TOKEN || secrets.GITHUB_TOKEN`
- Renamed from `GITHUB_MODELS_TOKEN` to `MODELS_TOKEN` (GitHub reserves `GITHUB_*` prefix)

**Testing**: Re-run Code Agent on story #243 after merge to validate API access with new PAT.

**Related**: Epic #242