### PR TITLE
Fix Test Agent: Use docker compose V2 syntax

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -2021,7 +2021,7 @@ jobs:
 
       - name: Start test services (PostgreSQL, Redis)
         run: |
-          docker-compose -f tests/docker-compose.test.yml up -d
+          docker compose -f tests/docker-compose.test.yml up -d
           echo "Waiting for services to be healthy..."
           sleep 10
 
@@ -2043,7 +2043,7 @@ jobs:
 
       - name: Stop test services
         if: always()
-        run: docker-compose -f tests/docker-compose.test.yml down
+        run: docker compose -f tests/docker-compose.test.yml down
 
       - name: Add testing labels + comment (real)
         uses: actions/github-script@v7


### PR DESCRIPTION
## Problem

Test Agent workflow failed on Epic #285 with:
```
docker-compose: command not found (exit code 127)
```

**Timeline:**
- PR #284 merged at 15:12:06Z ✅ (test infrastructure deployed)
- Epic #285 workflows ran at 15:23:41Z
- Test Agent failed to start Docker services
- Deploy Agent still created PR #293

**Root Cause:**  
GitHub Actions runners use Docker Compose V2 (plugin-based) which requires `docker compose` (with space) instead of `docker-compose` (hyphenated standalone binary).

## Solution

Changed 2 locations in [`.github/workflows/project-automation.yml`](.github/workflows/project-automation.yml):
- `docker-compose -f tests/docker-compose.test.yml up -d` → `docker compose -f ...`
- `docker-compose -f tests/docker-compose.test.yml down` → `docker compose -f ...`

## Testing Plan

After merge:
1. Create new test epic with `go-coding` label
2. Close all stories to trigger batch coding
3. Verify Docker services start successfully
4. Verify pytest runs with test dependencies
5. Verify Test Agent posts results to epic
6. Verify Deploy Agent creates PR with test summary

## Related

- Epic #285: First test with new infrastructure
- PR #284: Test infrastructure deployment
- Workflow run 21215171916: Failed Test Agent run

## Impact

✅ Fixes Test Agent Docker service startup  
✅ Enables comprehensive testing (unit + integration)  
✅ No breaking changes to other agents  
✅ Compatible with GitHub Actions runners