### PR TITLE
Fix: VG Analysis Cancellation Bug

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -402,7 +402,7 @@ jobs:
       contents: read
     concurrency:
       group: vg-${{ github.event.issue.number }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     if: |
       github.event_name == 'issues' &&
       needs.auto-triage.outputs.is_epic == 'true' &&


### PR DESCRIPTION
## Problem

VG Agent was only posting 4 of 7 parts and never adding `vg-approved` label, which blocked BA/SA from running.

## Root Cause

`cancel-in-progress: true` in VG job concurrency config was canceling the job mid-execution when multiple workflow runs triggered (e.g., when auto-triage adds labels).

## Solution

Changed `cancel-in-progress: false` for VG job. VG now completes all 7 parts and adds `vg-approved` label.

## Testing

Epic #304 stopped at Part 4/7. With this fix, new epics will complete all 7 parts and automatically trigger BA/SA.

## Impact

- ✅ VG completes all 7 analysis parts
- ✅ VG adds `vg-approved` label
- ✅ BA/SA trigger automatically
- ✅ Code generation pipeline unblocked