### PR TITLE
Fix: Code Agent Missing Repository Checkout

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1828,6 +1828,15 @@ jobs:
                 `Next: push real code + tests to the branch, ensure **WAOOAW CI** is green, then merge the PR.`
             });
 
+      - name: Checkout repository
+        if: |
+          steps.check-last-story.outputs.is_last_story == 'true' &&
+          steps.check-last-story.outputs.coding_allowed == 'true' &&
+          steps.ensure-implementation-pr.outputs.pr_number != ''
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Checkout epic branch for batch coding
         if: |
           steps.check-last-story.outputs.is_last_story == 'true' &&


### PR DESCRIPTION
## Problem

Code Agent workflow failed with `fatal: not in a git directory` when trying to checkout epic branch.

**Workflow run**: https://github.com/dlai-sd/WAOOAW/actions/runs/21219099538
**Epic**: #307
**Error**: Git commands executed without repository being checked out first

## Root Cause

The `Trigger Coding Agent` job was missing `actions/checkout@v4` step before running git commands to checkout the epic branch.

## Solution

Added `actions/checkout@v4` step with `fetch-depth: 0` (to get all branches) before the git checkout commands.

## Testing

After merging, re-trigger Epic #307:
1. Re-open one user story
2. Close it again
3. Verify Code Agent workflow completes successfully
4. Verify Aider generates code on epic branch

## Impact

- ✅ Code Agent can checkout epic branch
- ✅ Aider can run on correct branch
- ✅ Code committed to epic branch (not main)