### PR TITLE
fix(workflow): Add missing postChunkedComment function

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1929,6 +1929,30 @@ jobs:
               return;
             }
 
+            // Helper function to post comments with rate limit protection
+            async function postChunkedComment(body, delayMs = 500) {
+              try {
+                const response = await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: epicNumber,
+                  body: body
+                });
+                core.info(`Comment posted: ${response.data.id}`);
+                await new Promise(resolve => setTimeout(resolve, delayMs));
+                return response;
+              } catch (error) {
+                if (error.status === 403 && error.message.includes('rate limit')) {
+                  const resetTime = error.response?.headers?.['x-ratelimit-reset'] || 0;
+                  const waitMs = Math.max((resetTime * 1000) - Date.now(), 60000);
+                  core.warning(`Rate limited. Waiting ${waitMs}ms...`);
+                  await new Promise(resolve => setTimeout(resolve, waitMs));
+                  return postChunkedComment(body, delayMs);
+                }
+                throw error;
+              }
+            }
+
             // Get all user stories for this epic
             const allIssues = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,


### PR DESCRIPTION
## Problem

Epic #401 failed with:
```
ReferenceError: postChunkedComment is not defined
```

## Root Cause

Function `postChunkedComment` is called on line 2032+ in the "Run Batch Code Agent" script block, but the function is not defined in that scope.

The function exists in other script blocks (Vision Guardian, Business Analyst) but was missing from the Batch Code Agent block.

## Fix

Added `postChunkedComment` function definition at the start of the "Run Batch Code Agent" script block (line ~1923).

Function handles:
- GitHub API rate limiting (403 errors)
- Comment posting with retry logic
- Delays between comments (500ms) to avoid rate limits

## Files Changed

- `.github/workflows/project-automation.yml` (+24 lines)

## Validation

This is an existing bug in the workflow, not related to PR #400 changes.