### PR TITLE
fix(workflow): prevent empty epic_branch checkout failures

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -862,12 +862,13 @@ jobs:
               return;
             }
 
-            const branches = await github.rest.repos.listBranches({
+            const branches = await github.paginate(github.rest.repos.listBranches, {
               owner: context.repo.owner,
-              repo: context.repo.repo
+              repo: context.repo.repo,
+              per_page: 100
             });
 
-            const epicBranch = branches.data.find(b => b.name.startsWith('epic-' + epicNumber));
+            const epicBranch = branches.find(b => b.name.startsWith('epic-' + epicNumber));
             if (!epicBranch) {
               core.warning('Epic branch not found for epic #' + epicNumber);
               return;
@@ -1786,14 +1787,17 @@ jobs:
             core.info('Epic #' + epicNumber + ' - Open stories: ' + openStories.length);
             core.setOutput('is_last_story', openStories.length === 0 ? 'true' : 'false');
 
-            const branches = await github.rest.repos.listBranches({
+            const branches = await github.paginate(github.rest.repos.listBranches, {
               owner: context.repo.owner,
-              repo: context.repo.repo
+              repo: context.repo.repo,
+              per_page: 100
             });
 
-            const epicBranch = branches.data.find(b => b.name.startsWith('epic-' + epicNumber));
+            const epicBranch = branches.find(b => b.name.startsWith('epic-' + epicNumber));
             if (epicBranch) {
               core.setOutput('epic_branch', epicBranch.name);
+            } else {
+              core.warning('Epic branch not found for epic #' + epicNumber);
             }
 
       - name: Ensure implementation PR exists


### PR DESCRIPTION
Fixes the project automation workflow failing with "fatal: empty string is not a valid pathspec" when resolving an epic branch in repos with many branches.

Root cause: branch resolution used non-paginated listBranches, so epic branches beyond the first page were missed.

Change: use github.paginate(repos.listBranches, per_page=100) in both the doc-archiver and trigger-coding-agent branch resolution paths.

Expected impact: prevents downstream steps from running `git fetch origin ""` / `git checkout ""` during epic automation (e.g., #428 Technical Debt Paydown).