### PR TITLE
chore(devcontainer): alias DLAISD_PAT to GH_TOKEN

### DIFF
--- a/.devcontainer/00-token-alias.sh
+++ b/.devcontainer/00-token-alias.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Map a Codespaces secret (DLAISD_PAT) to standard GitHub CLI env vars.
+# This does not store the token value in the repo; it only aliases an env var.
+
+if [[ -n "${DLAISD_PAT:-}" ]]; then
+	# Prefer not to overwrite any existing tokens.
+	export GH_TOKEN="${GH_TOKEN:-$DLAISD_PAT}"
+	export GITHUB_TOKEN="${GITHUB_TOKEN:-$DLAISD_PAT}"
+fi

--- a/.devcontainer/setup-slim.sh
+++ b/.devcontainer/setup-slim.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+# Install token alias (if present) so GH_TOKEN/GITHUB_TOKEN are available in shells.
+if [ -f ".devcontainer/00-token-alias.sh" ]; then
+    install -m 0755 .devcontainer/00-token-alias.sh /etc/profile.d/00-waooaw-token-alias.sh
+fi
+
 set -e
 
 echo "🚀 WAOOAW Development Environment Setup"


### PR DESCRIPTION
Maps Codespaces secret DLAISD_PAT into commonly-used auth vars (GH_TOKEN/GITHUB_TOKEN) for shell sessions via /etc/profile.d, without committing any secret values.

Notes:
- Requires Codespace rebuild/restart for secret injection and profile.d to apply.