### PR TITLE
fix(ci): unblock TECH paydown batch deps

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1911,8 +1911,9 @@ jobs:
           steps.check-last-story.outputs.coding_allowed == 'true' &&
           steps.ensure-implementation-pr.outputs.pr_number != ''
         run: |
+          pip install -r tests/requirements.txt
           pip install requests aider-chat
-          pip install pytest pytest-cov flake8
+          pip install flake8
 
       - name: Run Batch Code Agent (Aider)
         if: |

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -27,9 +27,13 @@ pydantic-settings==2.1.0
 email-validator==2.1.0.post1  # Required by pydantic for EmailStr validation
 
 # Auth + Security (for auth testing)
+PyJWT==2.8.0
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
 cryptography==42.0.2
+
+# OAuth
+authlib==1.3.0
 
 # Cache (for caching tests)
 redis==5.0.1


### PR DESCRIPTION
Batch run 21293653905 failed in Trigger Testing Agent due to pytest collection/import errors (CP auth stack imports packages not present in tests/runtime deps).\n\nChanges:\n- Add missing deps to tests/requirements.txt: PyJWT + authlib\n- Ensure Trigger Coding Agent installs tests/requirements.txt so its internal pytest/coverage checks don't fail on missing modules\n\nExpected result: TECH paydown batch run proceeds past the beginning and tests execute normally.