### PR TITLE
fix(workflow): use main Deploy Agent on epic branch

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -2195,6 +2195,11 @@ jobs:
           git fetch origin "${{ needs.trigger-coding-agent.outputs.epic_branch }}"
           git checkout "${{ needs.trigger-coding-agent.outputs.epic_branch }}"
 
+      - name: Use latest Deploy Agent from main
+        run: |
+          git fetch origin main
+          git checkout origin/main -- scripts/deploy_agent.py
+
       - name: Use latest Test Agent + test requirements from main
         run: |
           git fetch origin main


### PR DESCRIPTION
Currently Trigger Deployment Agent checks out the epic branch and then runs scripts/deploy_agent.py from that branch. If the epic branch was created before Deploy Agent fixes land on main, reruns will execute stale logic.\n\nThis matches the earlier Testing Agent fix: after checking out the epic branch (so we deploy/test the epic code), we checkout scripts/deploy_agent.py from origin/main so the workflow always uses the latest deploy orchestration logic.