### PR TITLE
fix(aider): exclude google_auth.py stub from file discovery

### DIFF
--- a/scripts/batch_code_agent_aider.py
+++ b/scripts/batch_code_agent_aider.py
@@ -168,6 +168,7 @@ def discover_relevant_files(epic_number: str, stories: List[Story], *, roots: Op
                 "results.json",
                 "/__pycache__/",
                 "/node_modules/",
+                "/google_auth.py",  # Exclude legacy stub (causes Aider confusion)
             )
         ):
             return False


### PR DESCRIPTION
## Problem

Run #641 coding agent failed because Aider tried to 'fix' the `google_auth.py` stub file, which:
- Contains only a docstring and `pragma: no cover` comment  
- Aider created a broken `legacy_google_auth.py` file with IndentationError
- Aider removed the needed `verify_google_token` import from routes.py
- Unable to repair lint errors after 3 attempts

## Solution

Added `/google_auth.py` to the exclusion list in `batch_code_agent_aider.py`:
- Aider will skip this file during file discovery
- Prevents confusion from stub-only files
- Similar to existing exclusions for `node_modules`, `__pycache__`, etc.

## Impact

- ✅ Coding agent will no longer try to modify the stub
- ✅ Prevents creation of broken `legacy_google_auth.py` files  
- ✅ Keeps needed imports in place

## Testing

After merge, re-run epic-492 automation to verify coding agent succeeds.