### PR TITLE
fix: expose OPENAI_API_KEY to BA/SA job

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -929,6 +929,8 @@ jobs:
     permissions:
       issues: write
       contents: read
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     concurrency:
       group: ba-sa-${{ github.event.issue.number }}
       cancel-in-progress: true


### PR DESCRIPTION
## Problem
The OPENAI_API_KEY secret exists in repository secrets, but the `autonomous-ba-sa-trigger` job wasn't exposing it to the environment. This caused the Python agents to fail with:

```
Error: OPENAI_API_KEY environment variable required
```

## Solution
Added `env` section to the job definition to expose the secret:

```yaml
env:
  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
```

## Impact
- BA/SA agents can now access GPT-4o API
- Epic #519 workflow should succeed on re-run
- Foundation-based AI story generation will work

## Testing
- YAML lint passes
- Will test by re-running failed workflow for Epic #519