### PR TITLE
fix: remove backslash line continuations from execSync

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1081,12 +1081,17 @@ jobs:
                 core.info(`📝 Calling BA Agent (GPT-4o + Foundation context)...`);
 
                 try {
-                  const baCmd = `python3 scripts/business_analyst_agent.py \
-                    --epic-number ${epicNumber} \
-                    --epic-title "${epicTitle.replace(/"/g, '\\"')}" \
-                    --epic-body "${epicBody.replace(/"/g, '\\"')}" \
-                    --story-count ${targetStoryCount} \
-                    --output ${path.join(tempDir, 'ba-stories.json')}`;
+                  const baTitle = epicTitle.replace(/"/g, '\\"');
+                  const baBody = epicBody.replace(/"/g, '\\"');
+                  const baOutput = path.join(tempDir, 'ba-stories.json');
+                  const baCmd = [
+                    'python3 scripts/business_analyst_agent.py',
+                    `--epic-number ${epicNumber}`,
+                    `--epic-title "${baTitle}"`,
+                    `--epic-body "${baBody}"`,
+                    `--story-count ${targetStoryCount}`,
+                    `--output ${baOutput}`
+                  ].join(' ');
 
                   execSync(baCmd, {
                     cwd: process.env.GITHUB_WORKSPACE,
@@ -1114,10 +1119,7 @@ jobs:
                 core.info(`🏗️  Calling SA Agent (architecture guardian)...`);
 
                 try {
-                  const saCmd = `python3 scripts/systems_architect_agent.py \
-                    --epic-number ${epicNumber} \
-                    --stories-file ${baStoriesFile} \
-                    --output ${path.join(tempDir, 'sa-enhanced-stories.json')}`;
+                  const saCmd = `python3 scripts/systems_architect_agent.py --epic-number ${epicNumber} --stories-file ${baStoriesFile} --output ${path.join(tempDir, 'sa-enhanced-stories.json')}`;
 
                   execSync(saCmd, {
                     cwd: process.env.GITHUB_WORKSPACE,
@@ -1465,12 +1467,17 @@ jobs:
                 core.info(`📝 Calling BA Agent (GPT-4o + Foundation context)...`);
 
                 try {
-                  const baCmd = `python3 scripts/business_analyst_agent.py \
-                    --epic-number ${epicNumber} \
-                    --epic-title "${epicTitle.replace(/"/g, '\\"')}" \
-                    --epic-body "${epicBody.replace(/"/g, '\\"')}" \
-                    --story-count ${targetStoryCount} \
-                    --output ${path.join(tempDir, 'ba-stories.json')}`;
+                  const baTitle = epicTitle.replace(/"/g, '\\"');
+                  const baBody = epicBody.replace(/"/g, '\\"');
+                  const baOutput = path.join(tempDir, 'ba-stories.json');
+                  const baCmd = [
+                    'python3 scripts/business_analyst_agent.py',
+                    `--epic-number ${epicNumber}`,
+                    `--epic-title "${baTitle}"`,
+                    `--epic-body "${baBody}"`,
+                    `--story-count ${targetStoryCount}`,
+                    `--output ${baOutput}`
+                  ].join(' ');
 
                   execSync(baCmd, {
                     cwd: process.env.GITHUB_WORKSPACE,
@@ -1498,10 +1505,7 @@ jobs:
                 core.info(`🏗️  Calling SA Agent (architecture guardian)...`);
 
                 try {
-                  const saCmd = `python3 scripts/systems_architect_agent.py \
-                    --epic-number ${epicNumber} \
-                    --stories-file ${baStoriesFile} \
-                    --output ${path.join(tempDir, 'sa-enhanced-stories.json')}`;
+                  const saCmd = `python3 scripts/systems_architect_agent.py --epic-number ${epicNumber} --stories-file ${baStoriesFile} --output ${path.join(tempDir, 'sa-enhanced-stories.json')}`;
 
                   execSync(saCmd, {
                     cwd: process.env.GITHUB_WORKSPACE,


### PR DESCRIPTION
## Problem
The BA/SA workflow was failing with `HttpError: fetch failed`. It would post the intro comment but then fail immediately.

## Root Cause
**Backslash line continuations in JavaScript template literals don't work as shell line continuations.**

The code had:
```javascript
const baCmd = `python3 scripts/business_analyst_agent.py \\
  --epic-number ${epicNumber} \\
  --epic-title "${epicTitle}"`;
```

This creates a string with **literal backslash-newline characters**, not a valid shell command:
```
python3 scripts/business_analyst_agent.py \\n  --epic-number 519
```

When `execSync` tried to run this, it failed with a cryptic "fetch failed" error.

## Solution
- **Removed all backslashes** - commands are now single-line strings
- **Split long lines using `array.join(' ')`** for readability and to pass yamllint
- Applied fix to **both jobs**: `autonomous-ba-sa-trigger` and `label-triggered-ba-sa`

## Testing
- YAML lint passes
- Will test on Epic #519 after merge

## Why This Wasn't Caught
I tested the Python scripts locally with proper shell commands, but didn't test the workflow's JavaScript template literal handling. The error message ("fetch failed") was misleading - it made it seem like a GitHub API issue when it was actually a malformed shell command.