### PR TITLE
hotfix: Wrap comment updates in try-catch to prevent API failures

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1114,6 +1114,7 @@ jobs:
 
                   // Update comment - BA complete
                   const baUpdate = baIntro.replace(
+                  try {
                     "🔄 Starting BA Agent (GPT-4o + Foundation context)...",
                     `✅ **Completed** - Generated ${baStories.length} user stories with INVEST principles\n\n` +
                     "### 🏗️ Systems Architect Agent\n" +
@@ -1128,6 +1129,9 @@ jobs:
                     repo: context.repo.repo,
                     comment_id: commentId,
                     body: baUpdate
+                  } catch (commentError) {
+                    core.warning(`Failed to update BA comment: ${commentError.message}`);
+                  }
                   });
 
                 } catch (error) {
@@ -1587,6 +1591,7 @@ jobs:
                   const baStories = baData.stories || [];
 
                   // Update comment - BA complete
+                  try {
                   const baUpdate = baIntro.replace(
                     "🔄 Starting BA Agent (GPT-4o + Foundation context)...",
                     `✅ **Completed** - Generated ${baStories.length} user stories with INVEST principles\n\n` +
@@ -1601,6 +1606,9 @@ jobs:
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     comment_id: commentId,
+                  } catch (commentError) {
+                    core.warning(`Failed to update BA comment: ${commentError.message}`);
+                  }
                     body: baUpdate
                   });
 


### PR DESCRIPTION
## Missing from PR #526

PR #526 only had the baData initialization fix. This commit adds error handling for comment updates.

## Problem
BA agent succeeds but workflow fails when GitHub API returns "fetch failed" on comment update.

## Solution
Wrapped comment updates in try-catch blocks:
- Logs warning on failure
- Continues workflow execution
- Prevents successful BA/SA runs from failing due to transient API errors

## Locations
- autonomous-ba-sa-trigger job
- label-triggered-ba-sa job