### PR TITLE
fix(workflow): unblock BA/SA by fixing github-script SyntaxError

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1083,10 +1083,14 @@ jobs:
                 // Step 1: Call Business Analyst Agent
                 core.info(`📝 Calling BA Agent (GPT-4o + Foundation context)...`);
 
+                const baStoriesFile = path.join(tempDir, 'ba-stories.json');
+                let baStories = [];
+                let baUpdate = baIntro;
+
                 try {
                   const baTitle = epicTitle.replace(/"/g, '\\"');
                   const baBody = epicBody.replace(/"/g, '\\"');
-                  const baOutput = path.join(tempDir, 'ba-stories.json');
+                  const baOutput = baStoriesFile;
                   const baCmd = [
                     'python3 scripts/business_analyst_agent.py',
                     `--epic-number ${epicNumber}`,
@@ -1108,13 +1112,11 @@ jobs:
                   core.info('✅ BA Agent completed');
 
                   // Load BA stories first
-                  const baStoriesFile = path.join(tempDir, 'ba-stories.json');
                   const baData = JSON.parse(fs.readFileSync(baStoriesFile, 'utf8'));
-                  const baStories = baData.stories || [];
+                  baStories = baData.stories || [];
 
                   // Update comment - BA complete
-                  const baUpdate = baIntro.replace(
-                  try {
+                  baUpdate = baIntro.replace(
                     "🔄 Starting BA Agent (GPT-4o + Foundation context)...",
                     `✅ **Completed** - Generated ${baStories.length} user stories with INVEST principles\n\n` +
                     "### 🏗️ Systems Architect Agent\n" +
@@ -1124,32 +1126,33 @@ jobs:
                     "- ✅ **Business Analyst**: User story generation with INVEST principles"
                   );
 
-                  await github.rest.issues.updateComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    comment_id: commentId,
-                    body: baUpdate
+                  try {
+                    await github.rest.issues.updateComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      comment_id: commentId,
+                      body: baUpdate
+                    });
                   } catch (commentError) {
                     core.warning(`Failed to update BA comment: ${commentError.message}`);
                   }
-                  });
 
                 } catch (error) {
                   core.error(`BA Agent failed: ${error.message}`);
                   throw new Error(`BA Agent failed to generate stories`);
                 }
 
-                // BA data already loaded above
-                const baData = JSON.parse(fs.readFileSync(baStoriesFile, 'utf8'));
-                const baStories = baData.stories || [];
-
                 core.info(`📝 BA generated ${baStories.length} stories`);
 
                 // Step 3: Call Systems Architect Agent
                 core.info(`🏗️  Calling SA Agent (architecture guardian)...`);
 
+                const saStoriesFile = path.join(tempDir, 'sa-enhanced-stories.json');
+                let enhancedStories = [];
+                let saUpdate = baUpdate;
+
                 try {
-                  const saCmd = `python3 scripts/systems_architect_agent.py --epic-number ${epicNumber} --stories-file ${baStoriesFile} --output ${path.join(tempDir, 'sa-enhanced-stories.json')}`;
+                  const saCmd = `python3 scripts/systems_architect_agent.py --epic-number ${epicNumber} --stories-file ${baStoriesFile} --output ${saStoriesFile}`;
 
                   execSync(saCmd, {
                     cwd: process.env.GITHUB_WORKSPACE,
@@ -1561,10 +1564,14 @@ jobs:
                 // Call Business Analyst Agent
                 core.info(`📝 Calling BA Agent (GPT-4o + Foundation context)...`);
 
+                const baStoriesFile = path.join(tempDir, 'ba-stories.json');
+                let baStories = [];
+                let baUpdate = baIntro;
+
                 try {
                   const baTitle = epicTitle.replace(/"/g, '\\"');
                   const baBody = epicBody.replace(/"/g, '\\"');
-                  const baOutput = path.join(tempDir, 'ba-stories.json');
+                  const baOutput = baStoriesFile;
                   const baCmd = [
                     'python3 scripts/business_analyst_agent.py',
                     `--epic-number ${epicNumber}`,
@@ -1586,13 +1593,11 @@ jobs:
                   core.info('✅ BA Agent completed');
 
                   // Load BA stories first
-                  const baStoriesFile = path.join(tempDir, 'ba-stories.json');
                   const baData = JSON.parse(fs.readFileSync(baStoriesFile, 'utf8'));
-                  const baStories = baData.stories || [];
+                  baStories = baData.stories || [];
 
                   // Update comment - BA complete
-                  try {
-                  const baUpdate = baIntro.replace(
+                  baUpdate = baIntro.replace(
                     "🔄 Starting BA Agent (GPT-4o + Foundation context)...",
                     `✅ **Completed** - Generated ${baStories.length} user stories with INVEST principles\n\n` +
                     "### 🏗️ Systems Architect Agent\n" +
@@ -1602,32 +1607,33 @@ jobs:
                     "- ✅ **Business Analyst**: User story generation with INVEST principles"
                   );
 
-                  await github.rest.issues.updateComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    comment_id: commentId,
+                  try {
+                    await github.rest.issues.updateComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      comment_id: commentId,
+                      body: baUpdate
+                    });
                   } catch (commentError) {
                     core.warning(`Failed to update BA comment: ${commentError.message}`);
                   }
-                    body: baUpdate
-                  });
 
                 } catch (error) {
                   core.error(`BA Agent failed: ${error.message}`);
                   throw new Error(`BA Agent failed to generate stories`);
                 }
 
-                // BA data already loaded above
-                const baData = JSON.parse(fs.readFileSync(baStoriesFile, 'utf8'));
-                const baStories = baData.stories || [];
-
                 core.info(`📝 BA generated ${baStories.length} stories`);
 
                 // Call Systems Architect Agent
                 core.info(`🏗️  Calling SA Agent (architecture guardian)...`);
 
+                const saStoriesFile = path.join(tempDir, 'sa-enhanced-stories.json');
+                let enhancedStories = [];
+                let saUpdate = baUpdate;
+
                 try {
-                  const saCmd = `python3 scripts/systems_architect_agent.py --epic-number ${epicNumber} --stories-file ${baStoriesFile} --output ${path.join(tempDir, 'sa-enhanced-stories.json')}`;
+                  const saCmd = `python3 scripts/systems_architect_agent.py --epic-number ${epicNumber} --stories-file ${baStoriesFile} --output ${saStoriesFile}`;
 
                   execSync(saCmd, {
                     cwd: process.env.GITHUB_WORKSPACE,
@@ -1640,9 +1646,12 @@ jobs:
 
                   core.info('✅ SA Agent completed');
 
+                  // Load SA-enhanced stories before using them
+                  const saData = JSON.parse(fs.readFileSync(saStoriesFile, 'utf8'));
+                  enhancedStories = saData.enhanced_stories || [];
+
                   // Update comment - SA complete
-                  const enhancedStories = saData.enhanced_stories || [];
-                  const saUpdate = baUpdate.replace(
+                  saUpdate = baUpdate.replace(
                     "🔄 Starting SA Agent (adding STRIDE, performance budgets, observability)...",
                     `✅ **Completed** - Enhanced ${enhancedStories.length} stories with architecture guardian analysis\n\n` +
                     "### 📋 Creating GitHub Issues\n" +
@@ -1652,22 +1661,21 @@ jobs:
                     "- ✅ **Systems Architect**: Architecture guardian (STRIDE, performance, observability)"
                   );
 
-                  await github.rest.issues.updateComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    comment_id: commentId,
-                    body: saUpdate
-                  });
+                  try {
+                    await github.rest.issues.updateComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      comment_id: commentId,
+                      body: saUpdate
+                    });
+                  } catch (commentError) {
+                    core.warning(`Failed to update SA comment: ${commentError.message}`);
+                  }
 
                 } catch (error) {
                   core.error(`SA Agent failed: ${error.message}`);
                   throw new Error(`SA Agent failed to enhance stories`);
                 }
-
-                // Load SA-enhanced stories
-                const saStoriesFile = path.join(tempDir, 'sa-enhanced-stories.json');
-                const saData = JSON.parse(fs.readFileSync(saStoriesFile, 'utf8'));
-                const enhancedStories = saData.enhanced_stories || [];
 
                 core.info(`🏗️  SA enhanced ${enhancedStories.length} stories with architecture guardian analysis`);
 


### PR DESCRIPTION
Fixes the failing epic automation run (seen on epic #529) where actions/github-script crashed with: `SyntaxError: Unexpected token 'try'`.

Root cause:
- Malformed try/catch was inserted inside a `.replace(` call and inside the updateComment object literal in the BA completion section, producing invalid JS.

Changes:
- Compute `baUpdate`/`saUpdate` first, then wrap only the GitHub comment update calls in best-effort try/catch.
- Remove duplicate `const` declarations and make sure SA output is loaded before reading `enhancedStories`.

Impact:
- BA/SA orchestration can run end-to-end again; comment-update failures degrade gracefully instead of breaking the run.