### PR TITLE
fix(workflow): auto-create epic-* labels for BA/SA

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1287,6 +1287,29 @@ jobs:
                   };
                 });
 
+                // Ensure epic-scoped label exists (gh issue create fails if any label is missing)
+                const epicScopedLabel = `epic-${epicNumber}`;
+                try {
+                  await github.rest.issues.getLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: epicScopedLabel
+                  });
+                } catch (labelError) {
+                  if (labelError.status === 404) {
+                    await github.rest.issues.createLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name: epicScopedLabel,
+                      color: '5319e7',
+                      description: `Auto-created for Epic #${epicNumber}`
+                    });
+                    core.info(`Created missing label: ${epicScopedLabel}`);
+                  } else {
+                    throw labelError;
+                  }
+                }
+
 
                 // Step 6: Create GitHub issues from AI-enhanced stories using gh CLI
                 const ensuredStories = [];
@@ -1769,6 +1792,29 @@ jobs:
                     body: body
                   };
                 });
+
+                // Ensure epic-scoped label exists (gh issue create fails if any label is missing)
+                const epicScopedLabel = `epic-${epicNumber}`;
+                try {
+                  await github.rest.issues.getLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: epicScopedLabel
+                  });
+                } catch (labelError) {
+                  if (labelError.status === 404) {
+                    await github.rest.issues.createLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name: epicScopedLabel,
+                      color: '5319e7',
+                      description: `Auto-created for Epic #${epicNumber}`
+                    });
+                    core.info(`Created missing label: ${epicScopedLabel}`);
+                  } else {
+                    throw labelError;
+                  }
+                }
 
                 // Create GitHub issues
                 const ensuredStories = [];


### PR DESCRIPTION
Latest run failed creating story issues because the dynamic label  did not exist (e.g. ).  aborts if any  is missing.

Fix:
- Before creating BA/SA story issues, ensure the  label exists (create it on-demand if missing).
- Applies to both paths: new epic automation and label-triggered BA/SA rerun.

Repro (before):
- BA/SA Re-run job fails with .

Expected (after):
- Workflow auto-creates  label and proceeds to create the user stories.