### PR TITLE
fix(automation): remove hello stub + harden stub gate

### DIFF
--- a/src/Plant/BackEnd/core/hello.py
+++ b/src/Plant/BackEnd/core/hello.py
@@ -1,4 +1,0 @@
-def hello():
-    "print a greeting"
-
-    print("hello")


### PR DESCRIPTION
Removes unused placeholder file src/Plant/BackEnd/core/hello.py (no references).

Tightens stub detection in scripts/code_agent_aider.py to fail fast on placeholder hello stubs (e.g. hello.py containing def hello + print("hello")) and on added lines that include print("hello").

This prevents nonsense placeholder files from being committed/pushed by the Coding Agent.