### PR TITLE
fix(pp): point PP backend to Plant Gateway

### DIFF
--- a/cloud/terraform/stacks/pp/main.tf
+++ b/cloud/terraform/stacks/pp/main.tf
@@ -57,7 +57,9 @@ module "pp_backend" {
   max_instances = var.max_instances
 
   env_vars = {
-    ENVIRONMENT = var.environment
+    ENVIRONMENT       = var.environment
+    PLANT_GATEWAY_URL = "https://plant.${var.environment}.waooaw.com"
+    PLANT_API_URL     = "https://plant.${var.environment}.waooaw.com"
   }
 
   secrets = var.attach_secret_manager_secrets ? {


### PR DESCRIPTION
### What
- Set `PLANT_GATEWAY_URL` and `PLANT_API_URL` for PP backend to `https://plant.${var.environment}.waooaw.com`

### Why
- Unblocks `/api/{path}` proxy to Plant Gateway and `/api/pp/*` handlers that call Plant

### Verify (demo)
- https://pp.demo.waooaw.com/api/v1/agents (should no longer timeout)
- https://pp.demo.waooaw.com/api/pp/agents (should no longer 500)
