### PR TITLE
fix(plant-gateway): keep request.state.jwt dict

### DIFF
--- a/src/Plant/Gateway/middleware/auth.py
+++ b/src/Plant/Gateway/middleware/auth.py
@@ -304,7 +304,11 @@ class AuthMiddleware(BaseHTTPMiddleware):
             claims = validate_jwt(token)
             
             # Attach claims to request state
-            request.state.jwt = claims
+            # Most gateway middlewares treat request.state.jwt as a dict-like object
+            # (calling .get()). Keep that contract while also exposing the typed
+            # claims object for route-level dependencies.
+            request.state.jwt = claims.to_dict()
+            request.state.jwt_claims = claims
             request.state.user_id = claims.user_id
             request.state.customer_id = claims.customer_id
             request.state.roles = claims.roles
@@ -379,11 +383,24 @@ async def get_current_user(request: Request) -> JWTClaims:
     Raises:
         HTTPException: 401 if not authenticated
     """
-    if not hasattr(request.state, "jwt"):
+    if not hasattr(request.state, "jwt") and not hasattr(request.state, "jwt_claims"):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Not authenticated",
             headers={"WWW-Authenticate": "Bearer"},
         )
-    
-    return request.state.jwt
+
+    claims = getattr(request.state, "jwt_claims", None)
+    if claims is not None:
+        return claims
+
+    # Fallback for callers/tests that may have set request.state.jwt to a dict
+    jwt_dict = getattr(request.state, "jwt", None)
+    if isinstance(jwt_dict, dict):
+        return JWTClaims(jwt_dict)
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Not authenticated",
+        headers={"WWW-Authenticate": "Bearer"},
+    )


### PR DESCRIPTION
Fixes demo PP Agent Management 500s caused by Plant Gateway Policy middleware expecting request.state.jwt to be dict-like.\n\nRoot cause: Auth middleware stored request.state.jwt as JWTClaims object; policy/rbac/audit/budget call .get() and crash.\n\nChange:\n- Store request.state.jwt as claims.to_dict()\n- Also store request.state.jwt_claims for typed access\n- get_current_user returns typed claims\n\nRepro: call /api/v1/agents with a valid PP token -> 500. After this fix -> request proceeds.