### PR TITLE
fix(plant): make DB seed job imports reliable

### DIFF
--- a/.github/workflows/plant-db-migrations-job.yml
+++ b/.github/workflows/plant-db-migrations-job.yml
@@ -89,7 +89,7 @@ jobs:
             --region=${{ env.GCP_REGION }} \
             --project=${{ env.GCP_PROJECT_ID }} \
             --wait \
-            --args="python,database/seed_data.py"
+            --args="python,-m,database.seed_data"
 
       - name: View job logs
         if: always()

--- a/src/Plant/BackEnd/scripts/entrypoint.sh
+++ b/src/Plant/BackEnd/scripts/entrypoint.sh
@@ -23,7 +23,7 @@ case "$OPERATION" in
   
   seed)
     echo "🌱 Seeding Genesis data..."
-    python database/seed_data.py
+    python -m database.seed_data
     echo "✅ Seed complete"
     ;;
   
@@ -31,7 +31,7 @@ case "$OPERATION" in
     echo "🔄 Running migrations..."
     python -m alembic upgrade head
     echo "🌱 Seeding Genesis data..."
-    python database/seed_data.py
+    python -m database.seed_data
     echo "✅ Both operations complete"
     ;;
   


### PR DESCRIPTION
Fixes Plant demo DB seed runs by switching from script-path invocation (python database/seed_data.py) to module invocation (python -m database.seed_data), which keeps imports like core.* working in Cloud Run Jobs.\n\nAlso aligns the migrations container entrypoint to use the same invocation.