### PR TITLE
fix(gateway): allow /api/health without JWT

### DIFF
--- a/src/Plant/Gateway/middleware/auth.py
+++ b/src/Plant/Gateway/middleware/auth.py
@@ -55,6 +55,12 @@ PUBLIC_ENDPOINTS = [
     "/metrics",
 ]
 
+# Some deployments sit behind a proxy that prefixes application routes with `/api`.
+# Treat the `/api/*` equivalents of public endpoints as public as well.
+PUBLIC_ENDPOINTS = PUBLIC_ENDPOINTS + [
+    f"/api{path}" for path in PUBLIC_ENDPOINTS if not path.startswith("/api/")
+]
+
 
 class JWTClaims:
     """
@@ -263,7 +269,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
             Response object
         """
         # Skip authentication for public endpoints
-        if request.url.path in PUBLIC_ENDPOINTS:
+        # Note: Health endpoints may have nested paths (e.g. /api/health/stream).
+        if request.url.path in PUBLIC_ENDPOINTS or request.url.path.startswith("/api/health/"):
             logger.debug(f"Skipping auth for public endpoint: {request.url.path}")
             return await call_next(request)
         

--- a/src/Plant/Gateway/middleware/tests/test_auth.py
+++ b/src/Plant/Gateway/middleware/tests/test_auth.py
@@ -116,6 +116,11 @@ async def health():
     return {"status": "ok"}
 
 
+@app.get("/api/health")
+async def api_health():
+    return {"status": "ok"}
+
+
 @app.get("/api/v1/test")
 async def api_test_endpoint(request: Request):
     jwt_claims = getattr(request.state, "jwt", {})
@@ -466,6 +471,12 @@ def test_middleware_public_endpoint_no_auth():
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
+
+
+def test_middleware_public_api_prefixed_health_no_auth():
+    """Test /api/health bypasses authentication (proxy-prefixed health)."""
+    response = client.get("/api/health")
+    assert response.status_code == 200
 
 
 def test_middleware_public_endpoint_with_auth():

--- a/src/gateway/middleware/tests/test_auth.py
+++ b/src/gateway/middleware/tests/test_auth.py
@@ -116,6 +116,11 @@ async def health():
     return {"status": "ok"}
 
 
+@app.get("/api/health")
+async def api_health():
+    return {"status": "ok"}
+
+
 @app.get("/api/v1/test")
 async def api_test_endpoint(request: Request):
     jwt_claims = getattr(request.state, "jwt", {})
@@ -466,6 +471,12 @@ def test_middleware_public_endpoint_no_auth():
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
+
+
+def test_middleware_public_api_prefixed_health_no_auth():
+    """Test /api/health bypasses authentication (proxy-prefixed health)."""
+    response = client.get("/api/health")
+    assert response.status_code == 200
 
 
 def test_middleware_public_endpoint_with_auth():


### PR DESCRIPTION
Fixes demo probes/monitors failing on /api/health when a proxy prefixes routes with /api.

Changes:
- Treat /api-prefixed public endpoints as public in gateway auth middleware
- Add coverage for /api/health bypass in middleware tests

Validation (Docker-only):
- pytest Plant Gateway middleware auth public endpoint tests
- pytest shared gateway middleware auth public endpoint tests