### PR TITLE
fix(pp-frontend): Handle non-string error properties in isTokenExpiredProblem

### DIFF
--- a/src/PP/FrontEnd/src/services/gatewayApiClient.ts
+++ b/src/PP/FrontEnd/src/services/gatewayApiClient.ts
@@ -37,9 +37,9 @@ const AUTH_EXPIRED_FLAG = 'waooaw:auth-expired'
 const DB_UPDATES_TOKEN_STORAGE_KEY = 'pp_db_access_token'
 
 function isTokenExpiredProblem(problem?: ApiProblemDetails): boolean {
-  const type = (problem?.type || '').toLowerCase()
-  const title = (problem?.title || '').toLowerCase()
-  const detail = (problem?.detail || '').toLowerCase()
+  const type = String(problem?.type || '').toLowerCase()
+  const title = String(problem?.title || '').toLowerCase()
+  const detail = String(problem?.detail || '').toLowerCase()
   return type.includes('token-expired') || title === 'token expired' || detail.includes('token has expired')
 }
 


### PR DESCRIPTION
## Problem
User experiencing **** error in PP Frontend when:
- Navigating to Database Connection screen
- Clicking 'DB Updates' menu
- Error: `((intermediate value)(intermediate value)(intermediate value) || "").toLowerCase is not a function`

## Root Cause
The `isTokenExpiredProblem()` function in `gatewayApiClient.ts` directly calls `.toLowerCase()` on error response properties without ensuring they are strings first.

When the backend returns non-string error properties (e.g., numeric error codes, boolean flags), the function crashes.

## Fix
Wrap all error properties in `String()` before calling `.toLowerCase()`:

```typescript
function isTokenExpiredProblem(problem?: ApiProblemDetails): boolean {
  const type = String(problem?.type || '').toLowerCase()
  const title = String(problem?.title || '').toLowerCase()
  const detail = String(problem?.detail || '').toLowerCase()
  return type.includes('token-expired') || title === 'token expired' || detail.includes('token has expired')
}
```

## Testing
✅ Safely handles:
- String values (original behavior)
- Number values (e.g., error codes)
- Boolean values  
- null/undefined values
- Empty values

## Impact
- **File Changed**: `src/PP/FrontEnd/src/services/gatewayApiClient.ts`
- **Lines Changed**: 3 (lines 40-42)
- **Risk**: Low (defensive coding, no behavior change for valid strings)

## Deployment
After merge, redeploy PP Frontend to resolve the error.

## Related
This fix was originally made in the feature branch (commit 424710f) but wasn't merged to main before deployment.