### PR TITLE
fix(cp-frontend): restore marketplace visuals

### DIFF
--- a/src/CP/FrontEnd/src/sections/MarketplaceSection.tsx
+++ b/src/CP/FrontEnd/src/sections/MarketplaceSection.tsx
@@ -1,4 +1,4 @@
-import { Card, Text } from '@fluentui/react-components'
+import AgentCard from '../components/AgentCard'
 import { mockAgents } from '../lib/mockData'
 
 export default function MarketplaceSection() {
@@ -6,20 +6,8 @@ export default function MarketplaceSection() {
     <section className="marketplace-section">
       <div className="container">
         <div className="agents-grid">
-          {mockAgents.map((agent) => (
-            <Card key={agent.id}>
-              <div style={{ padding: '1rem' }}>
-                <Text weight="semibold">
-                  {agent.avatar} {agent.name}
-                </Text>
-                <div style={{ marginTop: '0.25rem' }}>
-                  <Text size={200}>{agent.industry}</Text>
-                </div>
-                <div style={{ marginTop: '0.25rem' }}>
-                  <Text size={200}>{agent.specialty}</Text>
-                </div>
-              </div>
-            </Card>
+          {mockAgents.slice(0, 6).map((agent) => (
+            <AgentCard key={agent.id} agent={agent as any} />
           ))}
         </div>
       </div>


### PR DESCRIPTION
Restores the original AgentCard-based marketplace visuals while keeping the marketplace section fully static (mockAgents only, no Plant API calls).

- Reverts MarketplaceSection to render AgentCard (original look/feel)
- Keeps the session/unauthorized fix by avoiding any network calls on landing

Test (Docker):
- docker compose -f docker-compose.local.yml run --rm cp-frontend-test npm test -- --run src/test/MarketplaceSection.test.tsx