### PR TITLE
fix(cp): reject duplicate email/phone registrations

### DIFF
--- a/src/CP/BackEnd/tests/test_cp_otp_login_routes.py
+++ b/src/CP/BackEnd/tests/test_cp_otp_login_routes.py
@@ -7,6 +7,10 @@ def test_cp_otp_login_start_and_verify_returns_tokens(client, monkeypatch, tmp_p
     monkeypatch.setenv("CP_REGISTRATIONS_STORE_PATH", str(reg_path))
     monkeypatch.setenv("CP_OTP_STORE_PATH", str(otp_path))
 
+    from services import cp_registrations
+
+    cp_registrations.default_cp_registration_store.cache_clear()
+
     # Avoid calling Plant gateway during tests.
     async def _noop_upsert(record):
         return None
@@ -76,6 +80,10 @@ def test_cp_otp_login_start_production_calls_delivery_and_hides_code(client, mon
     monkeypatch.setenv("CP_REGISTRATIONS_STORE_PATH", str(reg_path))
     monkeypatch.setenv("CP_OTP_STORE_PATH", str(otp_path))
     monkeypatch.setenv("CP_OTP_FIXED_CODE", "123456")
+
+    from services import cp_registrations
+
+    cp_registrations.default_cp_registration_store.cache_clear()
 
     async def _noop_upsert(record):
         return None

--- a/src/CP/BackEnd/tests/test_cp_registration_routes.py
+++ b/src/CP/BackEnd/tests/test_cp_registration_routes.py
@@ -87,3 +87,63 @@ def test_cp_register_rejects_bad_phone_format(client, monkeypatch, tmp_path):
 
     resp = client.post("/api/cp/auth/register", json=payload)
     assert resp.status_code == 422
+
+
+@pytest.mark.unit
+def test_cp_register_duplicate_email_returns_409(client, monkeypatch, tmp_path):
+    store_path = tmp_path / "cp_registrations.jsonl"
+    monkeypatch.setenv("CP_REGISTRATIONS_STORE_PATH", str(store_path))
+
+    from services import cp_registrations
+
+    cp_registrations.default_cp_registration_store.cache_clear()
+
+    payload = {
+        "fullName": "Test User",
+        "businessName": "ACME",
+        "businessIndustry": "marketing",
+        "businessAddress": "Bengaluru",
+        "email": "test@example.com",
+        "phone": "+919876543210",
+        "preferredContactMethod": "email",
+        "consent": True,
+    }
+
+    first = client.post("/api/cp/auth/register", json=payload)
+    assert first.status_code == 201
+
+    second_payload = dict(payload)
+    second_payload["phone"] = "+919876543211"
+    second = client.post("/api/cp/auth/register", json=second_payload)
+    assert second.status_code == 409
+    assert "Email already registered" in second.text
+
+
+@pytest.mark.unit
+def test_cp_register_duplicate_phone_returns_409(client, monkeypatch, tmp_path):
+    store_path = tmp_path / "cp_registrations.jsonl"
+    monkeypatch.setenv("CP_REGISTRATIONS_STORE_PATH", str(store_path))
+
+    from services import cp_registrations
+
+    cp_registrations.default_cp_registration_store.cache_clear()
+
+    payload = {
+        "fullName": "Test User",
+        "businessName": "ACME",
+        "businessIndustry": "marketing",
+        "businessAddress": "Bengaluru",
+        "email": "test@example.com",
+        "phone": "+919876543210",
+        "preferredContactMethod": "email",
+        "consent": True,
+    }
+
+    first = client.post("/api/cp/auth/register", json=payload)
+    assert first.status_code == 201
+
+    second_payload = dict(payload)
+    second_payload["email"] = "other@example.com"
+    second = client.post("/api/cp/auth/register", json=second_payload)
+    assert second.status_code == 409
+    assert "Phone already registered" in second.text


### PR DESCRIPTION
Prevents minting multiple CP registration_ids for the same email/phone by returning HTTP 409 on duplicates.

Tests: ============================= test session starts ==============================
platform linux -- Python 3.11.14, pytest-7.4.4, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
rootdir: /app
configfile: pytest.ini
testpaths: tests
plugins: anyio-4.12.1, asyncio-0.21.1, mock-3.12.0, cov-4.1.0
asyncio: mode=Mode.AUTO
collecting ... collected 154 items

tests/test_2fa_totp.py::test_2fa_enroll_confirm_and_login_requires_totp PASSED [  0%]
tests/test_auth.py::test_health_endpoint PASSED                          [  1%]
tests/test_auth.py::test_get_current_user_unauthorized PASSED            [  1%]
tests/test_auth.py::test_google_login_endpoint_exists PASSED             [  2%]
tests/test_auth_load.py::TestAuthAPILoad::test_concurrent_user_registrations SKIPPED [  3%]
tests/test_auth_load.py::TestAuthAPILoad::test_concurrent_logins SKIPPED [  3%]
tests/test_auth_load.py::TestAuthAPILoad::test_auth_api_response_times SKIPPED [  4%]
tests/test_auth_load.py::TestAuthAPILoad::test_jwt_token_validation_load SKIPPED [  5%]
tests/test_auth_load.py::TestAuthAPILoad::test_password_hashing_performance SKIPPED [  5%]
tests/test_auth_models.py::TestUserRegisterSchema::test_valid_user_register PASSED [  6%]
tests/test_auth_models.py::TestUserRegisterSchema::test_user_register_invalid_email PASSED [  7%]
tests/test_auth_models.py::TestUserRegisterSchema::test_user_register_missing_password PASSED [  7%]
tests/test_auth_models.py::TestUserRegisterSchema::test_user_register_missing_full_name PASSED [  8%]
tests/test_auth_models.py::TestUserRegisterSchema::test_user_register_email_normalization PASSED [  9%]
tests/test_auth_models.py::TestUserLoginSchema::test_valid_user_login PASSED [  9%]
tests/test_auth_models.py::TestUserLoginSchema::test_user_login_invalid_email PASSED [ 10%]
tests/test_auth_models.py::TestUserLoginSchema::test_user_login_missing_fields PASSED [ 11%]
tests/test_auth_models.py::TestTokenSchemas::test_valid_token_response PASSED [ 11%]
tests/test_auth_models.py::TestTokenSchemas::test_token_data_extraction PASSED [ 12%]
tests/test_config.py::test_cors_origins_list_wildcard PASSED             [ 12%]
tests/test_config.py::test_access_token_expire_seconds PASSED            [ 13%]
tests/test_config.py::test_refresh_token_expire_seconds PASSED           [ 14%]
tests/test_config.py::test_get_settings_returns_singleton PASSED         [ 14%]
tests/test_cp_otp_login_routes.py::test_cp_otp_login_start_and_verify_returns_tokens PASSED [ 15%]
tests/test_cp_otp_login_routes.py::test_cp_otp_login_start_production_calls_delivery_and_hides_code PASSED [ 16%]
tests/test_cp_otp_routes.py::test_cp_upsert_customer_missing_key_nonprod_is_best_effort PASSED [ 16%]
tests/test_cp_otp_routes.py::test_cp_upsert_customer_missing_key_prod_raises PASSED [ 17%]
tests/test_cp_otp_routes.py::test_cp_upsert_customer_plant_5xx_demo_is_best_effort PASSED [ 18%]
tests/test_cp_otp_routes.py::test_cp_upsert_customer_plant_5xx_uat_raises PASSED [ 18%]
tests/test_cp_otp_routes.py::test_cp_otp_start_and_verify_returns_tokens PASSED [ 19%]
tests/test_cp_otp_routes.py::test_cp_otp_rate_limit PASSED               [ 20%]
tests/test_cp_otp_routes.py::test_cp_otp_verify_rejects_bad_code PASSED  [ 20%]
tests/test_cp_otp_routes.py::test_cp_otp_start_production_calls_delivery_and_hides_code PASSED [ 21%]
tests/test_cp_otp_routes.py::test_cp_otp_start_production_without_provider_returns_500 PASSED [ 22%]
tests/test_cp_otp_routes.py::test_cp_otp_start_demo_skips_delivery_and_echoes_code PASSED [ 22%]
tests/test_cp_registration_routes.py::test_cp_register_happy_path_mints_id_and_normalizes PASSED [ 23%]
tests/test_cp_registration_routes.py::test_cp_register_requires_consent PASSED [ 24%]
tests/test_cp_registration_routes.py::test_cp_register_rejects_bad_phone_format PASSED [ 24%]
tests/test_cp_registration_routes.py::test_cp_register_duplicate_email_returns_409 PASSED [ 25%]
tests/test_cp_registration_routes.py::test_cp_register_duplicate_phone_returns_409 PASSED [ 25%]
tests/test_debug_routes.py::test_list_all_routes PASSED                  [ 26%]
tests/test_dependencies.py::test_get_current_user_success PASSED         [ 27%]
tests/test_dependencies.py::test_get_current_user_invalid_token_type PASSED [ 27%]
tests/test_dependencies.py::test_get_current_user_user_not_found PASSED  [ 28%]
tests/test_dependencies.py::test_get_current_user_optional_with_valid_token PASSED [ 29%]
tests/test_dependencies.py::test_get_current_user_optional_no_credentials PASSED [ 29%]
tests/test_dependencies.py::test_get_current_user_optional_invalid_token PASSED [ 30%]
tests/test_dependencies.py::test_verify_refresh_token_success PASSED     [ 31%]
tests/test_dependencies.py::test_verify_refresh_token_with_access_token PASSED [ 31%]
tests/test_exchange_setup_routes.py::test_exchange_setup_upsert_and_list PASSED [ 32%]
tests/test_google_oauth.py::test_get_authorization_url_contains_expected_params PASSED [ 33%]
tests/test_google_oauth.py::test_get_user_from_google_raises_when_access_token_missing PASSED [ 33%]
tests/test_google_oauth.py::test_get_user_from_google_happy_path PASSED  [ 34%]
tests/test_google_oauth_integration.py::TestGoogleOAuthIntegration::test_google_login_redirect PASSED [ 35%]
tests/test_google_oauth_integration.py::TestGoogleOAuthIntegration::test_google_login_with_source PASSED [ 35%]
tests/test_google_oauth_integration.py::TestGoogleOAuthIntegration::test_google_verify_token_success PASSED [ 36%]
tests/test_google_oauth_integration.py::TestGoogleOAuthIntegration::test_google_verify_token_invalid PASSED [ 37%]
tests/test_google_oauth_integration.py::TestGoogleOAuthIntegration::test_google_auth_creates_new_user PASSED [ 37%]
tests/test_google_oauth_integration.py::TestGoogleOAuthIntegration::test_google_auth_existing_user PASSED [ 38%]
tests/test_google_oauth_integration.py::TestGoogleOAuthIntegration::test_refresh_token_endpoint PASSED [ 38%]
tests/test_google_oauth_integration.py::TestGoogleOAuthIntegration::test_get_current_user PASSED [ 39%]
tests/test_google_oauth_integration.py::TestGoogleOAuthIntegration::test_get_current_user_no_token PASSED [ 40%]
tests/test_google_oauth_integration.py::TestGoogleOAuthIntegration::test_get_current_user_invalid_token PASSED [ 40%]
tests/test_google_oauth_integration.py::TestGoogleOAuthIntegration::test_logout PASSED [ 41%]
tests/test_google_oauth_integration.py::TestGoogleOAuthIntegration::test_logout_revokes_refresh_token PASSED [ 42%]
tests/test_google_oauth_integration.py::TestGoogleOAuthIntegration::test_health_check PASSED [ 42%]
tests/test_google_oauth_integration.py::TestGoogleOAuthIntegration::test_complete_oauth_flow PASSED [ 43%]
tests/test_hire_wizard_routes.py::test_hire_wizard_draft_is_persisted_cp_local PASSED [ 44%]
tests/test_hire_wizard_routes.py::test_hire_wizard_delegates_to_plant_when_enabled PASSED [ 44%]
tests/test_hire_wizard_routes.py::test_hire_wizard_finalize_delegates_to_plant_when_enabled PASSED [ 45%]
tests/test_hired_agents_proxy.py::test_cp_hired_agents_get_by_subscription_injects_customer_id PASSED [ 46%]
tests/test_hired_agents_proxy.py::test_cp_hired_agents_returns_503_when_plant_url_missing PASSED [ 46%]
tests/test_hired_agents_proxy.py::test_plant_get_json_converts_network_error_to_runtime_error PASSED [ 47%]
tests/test_hired_agents_proxy.py::test_plant_get_json_rejects_non_dict_payload PASSED [ 48%]
tests/test_hired_agents_proxy.py::test_cp_hired_agents_put_draft_injects_customer_id PASSED [ 48%]
tests/test_hired_agents_proxy.py::test_cp_hired_agents_goals_inject_customer_id_and_forward PASSED [ 49%]
tests/test_hired_agents_proxy.py::test_cp_hired_agents_deliverables_inject_customer_id_and_forward PASSED [ 50%]
tests/test_integration.py::test_api_health_check PASSED                  [ 50%]
tests/test_integration.py::test_auth_health_check PASSED                 [ 51%]
tests/test_integration.py::test_api_docs_available PASSED                [ 51%]
tests/test_internal_plant_credential_resolver.py::test_resolve_credential_success PASSED [ 52%]
tests/test_internal_plant_credential_resolver.py::test_resolve_credential_not_found PASSED [ 53%]
tests/test_internal_plant_credential_resolver.py::test_resolve_credential_invalid_api_key PASSED [ 53%]
tests/test_internal_plant_credential_resolver.py::test_update_access_token_success PASSED [ 54%]
tests/test_internal_plant_credential_resolver.py::test_update_access_token_not_found PASSED [ 55%]
tests/test_internal_plant_credential_resolver.py::test_resolve_credential_different_customer PASSED [ 55%]
tests/test_invoices_routes.py::test_cp_invoices_list_proxies_to_plant PASSED [ 56%]
tests/test_jwt.py::test_create_access_token PASSED                       [ 57%]
tests/test_jwt.py::test_create_refresh_token PASSED                      [ 57%]
tests/test_jwt.py::test_tokens_are_different PASSED                      [ 58%]
tests/test_jwt_advanced.py::test_create_token_pair PASSED                [ 59%]
tests/test_jwt_advanced.py::test_decode_token_expired PASSED             [ 59%]
tests/test_jwt_advanced.py::test_decode_token_invalid_signature PASSED   [ 60%]
tests/test_jwt_advanced.py::test_decode_token_missing_user_id PASSED     [ 61%]
tests/test_jwt_advanced.py::test_decode_token_missing_email PASSED       [ 61%]
tests/test_jwt_advanced.py::test_decode_token_malformed PASSED           [ 62%]
tests/test_jwt_advanced.py::test_create_tokens_convenience_function PASSED [ 62%]
tests/test_jwt_advanced.py::test_verify_token_convenience_function PASSED [ 63%]
tests/test_jwt_advanced.py::test_token_data_model PASSED                 [ 64%]
tests/test_jwt_advanced.py::test_access_token_expiry PASSED              [ 64%]
tests/test_jwt_advanced.py::test_refresh_token_expiry PASSED             [ 65%]
tests/test_marketing_review_routes.py::test_marketing_review_list_and_approve PASSED [ 66%]
tests/test_marketing_review_routes.py::test_marketing_review_schedule PASSED [ 66%]
tests/test_my_agents_summary_routes.py::test_cp_my_agents_summary_cp_local PASSED [ 67%]
tests/test_my_agents_summary_routes.py::test_cp_my_agents_summary_delegates_subscription_listing_to_plant PASSED [ 68%]
tests/test_my_agents_summary_routes.py::test_list_subscriptions_plant_mode_rejects_non_list PASSED [ 68%]
tests/test_my_agents_summary_routes.py::test_list_subscriptions_plant_mode_requires_base_url PASSED [ 69%]
tests/test_my_agents_summary_routes.py::test_enrich_with_hired_agent_ignores_404 PASSED [ 70%]
tests/test_my_agents_summary_routes.py::test_enrich_with_hired_agent_maps_datetime_fields PASSED [ 70%]
tests/test_payments_config_routes.py::test_payments_config_defaults_to_coupon_in_dev PASSED [ 71%]
tests/test_payments_config_routes.py::test_payments_config_defaults_to_razorpay_in_prod PASSED [ 72%]
tests/test_payments_config_routes.py::test_payments_config_rejects_coupon_mode_in_prod PASSED [ 72%]
tests/test_payments_config_routes.py::test_payments_config_rejects_invalid_mode PASSED [ 73%]
tests/test_payments_coupon_routes.py::test_coupon_checkout_happy_path PASSED [ 74%]
tests/test_payments_coupon_routes.py::test_coupon_checkout_delegates_to_plant_when_configured PASSED [ 74%]
tests/test_payments_coupon_routes.py::test_coupon_checkout_rejects_invalid_code PASSED [ 75%]
tests/test_payments_coupon_routes.py::test_coupon_checkout_disabled_when_not_coupon_mode PASSED [ 75%]
tests/test_payments_razorpay_routes.py::test_razorpay_order_disabled_when_not_razorpay_mode PASSED [ 76%]
tests/test_payments_razorpay_routes.py::test_razorpay_order_delegates_to_plant_when_configured PASSED [ 77%]
tests/test_payments_razorpay_routes.py::test_razorpay_confirm_delegates_to_plant_when_configured PASSED [ 77%]
tests/test_platform_credentials_routes.py::test_platform_credentials_upsert_and_list PASSED [ 78%]
tests/test_proxy.py::test_auth_routes_are_local_and_not_proxied PASSED   [ 79%]
tests/test_proxy.py::test_non_auth_api_routes_are_proxied PASSED         [ 79%]
tests/test_proxy.py::test_proxy_strips_inbound_metering_headers PASSED   [ 80%]
tests/test_proxy.py::test_proxy_forwards_correlation_id_when_present PASSED [ 81%]
tests/test_proxy.py::test_proxy_generates_correlation_id_when_missing PASSED [ 81%]
tests/test_proxy.py::test_proxy_forwards_debug_trace_when_requested PASSED [ 82%]
tests/test_proxy.py::test_proxy_forwards_authorization_header_when_present PASSED [ 83%]
tests/test_proxy.py::test_proxy_enables_debug_trace_when_debug_verbose PASSED [ 83%]
tests/test_receipts_routes.py::test_cp_receipts_list_proxies_to_plant PASSED [ 84%]
tests/test_routes.py::test_refresh_token_with_invalid_token PASSED       [ 85%]
tests/test_routes.py::test_google_login_redirects_with_state PASSED      [ 85%]
tests/test_routes.py::test_google_callback_with_error PASSED             [ 86%]
tests/test_routes.py::test_google_callback_missing_params PASSED         [ 87%]
tests/test_routes.py::test_google_callback_invalid_state PASSED          [ 87%]
tests/test_routes.py::test_google_callback_success_flow PASSED           [ 88%]
tests/test_routes.py::test_google_callback_auth_failure PASSED           [ 88%]
tests/test_subscriptions_routes.py::test_cp_subscriptions_list_and_cancel_cp_local PASSED [ 89%]
tests/test_subscriptions_routes.py::test_cp_subscriptions_delegates_to_plant_when_enabled PASSED [ 90%]
tests/test_trading_routes.py::test_trading_draft_and_approve_execute PASSED [ 90%]
tests/test_trading_strategy_routes.py::test_trading_strategy_upsert_and_list PASSED [ 91%]
tests/test_user_store.py::test_create_user PASSED                        [ 92%]
tests/test_user_store.py::test_get_user_by_id PASSED                     [ 92%]
tests/test_user_store.py::test_get_user_by_id_not_found PASSED           [ 93%]
tests/test_user_store.py::test_get_user_by_email PASSED                  [ 94%]
tests/test_user_store.py::test_get_user_by_email_not_found PASSED        [ 94%]
tests/test_user_store.py::test_get_user_by_provider PASSED               [ 95%]
tests/test_user_store.py::test_get_user_by_provider_not_found PASSED     [ 96%]
tests/test_user_store.py::test_update_last_login PASSED                  [ 96%]
tests/test_user_store.py::test_update_last_login_nonexistent_user PASSED [ 97%]
tests/test_user_store.py::test_get_or_create_user_creates_new PASSED     [ 98%]
tests/test_user_store.py::test_get_or_create_user_finds_by_provider PASSED [ 98%]
tests/test_user_store.py::test_get_or_create_user_finds_by_email PASSED  [ 99%]
tests/test_user_store.py::test_get_user_store_singleton PASSED           [100%]

=============================== warnings summary ===============================
core/database.py:13
  /app/core/database.py:13: MovedIn20Warning: The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). (deprecated since: 2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    Base = declarative_base()

../usr/local/lib/python3.11/site-packages/passlib/utils/__init__.py:854
  /usr/local/lib/python3.11/site-packages/passlib/utils/__init__.py:854: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13
    from crypt import crypt as _crypt

main.py:109
  /app/main.py:109: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    @app.on_event("shutdown")

../usr/local/lib/python3.11/site-packages/fastapi/applications.py:4576
  /usr/local/lib/python3.11/site-packages/fastapi/applications.py:4576: DeprecationWarning: 
          on_event is deprecated, use lifespan event handlers instead.
  
          Read more about it in the
          [FastAPI docs for Lifespan Events](https://fastapi.tiangolo.com/advanced/events/).
          
    return self.router.on_event(event_type)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

---------- coverage: platform linux, python 3.11.14-final-0 ----------
Name                                        Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------
api/__init__.py                                 3      0   100%
api/auth/__init__.py                            2      0   100%
api/auth/dependencies.py                       37      0   100%
api/auth/google_oauth.py                       49     24    51%   70-89, 105-118, 134-153, 183
api/auth/routes.py                            115     12    90%   69, 148, 186, 270, 272, 288-295
api/auth/user_store.py                         45      0   100%
api/auth_email.py                              30     13    57%   21, 50-54, 100-104, 134, 169
api/cp_otp.py                                 160     29    82%   44, 52-53, 92-99, 107-113, 118, 160, 178, 180-182, 221, 227, 279, 283, 293, 296, 353, 357
api/cp_registration.py                        123     32    74%   42-82, 119, 126, 144, 146, 156, 158, 182
api/exchange_setup.py                          49      4    92%   42, 44, 77, 79
api/hire_wizard.py                            107     38    64%   67-90, 101-122, 153-154, 159-174, 202, 239-253
api/hired_agents_proxy.py                     241     71    71%   38, 40, 45, 55-75, 85-105, 109-129, 262-263, 295-296, 318-319, 350-351, 371-372, 394-395, 425-426
api/internal_plant_credential_resolver.py      49      2    96%   97, 145
api/invoices.py                                65     32    51%   27, 53-54, 57, 67-75, 84-92, 101-115
api/marketing_review.py                       122     17    86%   30-31, 41, 44, 54, 67, 79, 99, 101, 110, 113, 151, 218, 223, 227, 240, 249
api/my_agents_summary.py                      103     16    84%   40-43, 129-131, 134, 140, 143, 171-172, 176-179, 182
api/payments_config.py                         34      0   100%
api/payments_coupon.py                         72     16    78%   70-97, 134-135
api/payments_razorpay.py                       86     32    63%   69-93, 105-131, 161, 190
api/platform_credentials.py                    26      0   100%
api/receipts.py                                65     32    51%   27, 57-58, 61, 71-79, 88-96, 105-119
api/subscriptions.py                           95     46    52%   49-65, 69-83, 89, 121-122, 133-159, 179, 181, 191-192
api/trading.py                                 57      8    86%   33-34, 44, 47, 93, 97, 136, 140
api/trading_strategy.py                        30      0   100%
core/__init__.py                                2      0   100%
core/config.py                                 35      1    97%   51
core/database.py                               16      6    62%   45-49, 63-64
core/jwt_handler.py                            47      0   100%
core/security.py                                6      2    67%   21, 35
models/__init__.py                              2      0   100%
models/user.py                                 49      0   100%
models/user_db.py                              15      1    93%   30
-------------------------------------------------------------------------
TOTAL                                        1937    434    78%
Coverage HTML written to dir htmlcov
Coverage XML written to file coverage.xml

Required test coverage of 76% reached. Total coverage: 77.59%
================== 149 passed, 5 skipped, 4 warnings in 3.23s ================== (149 passed, 5 skipped, coverage 77.59%).