### PR TITLE
feat: Add Google Play Store deployment workflow

### DIFF
--- a/.github/workflows/mobile-playstore-deploy.yml
+++ b/.github/workflows/mobile-playstore-deploy.yml
@@ -39,7 +39,7 @@ jobs:
       track: ${{ steps.config.outputs.track }}
       build-profile: ${{ steps.config.outputs.build-profile }}
       is-production: ${{ steps.config.outputs.is-production }}
-    
+
     steps:
       - name: Determine deployment configuration
         id: config
@@ -51,7 +51,7 @@ jobs:
             echo "version=manual-${{ github.run_number }}" >> $GITHUB_OUTPUT
             echo "build-profile=${{ github.event.inputs.environment }}-store" >> $GITHUB_OUTPUT
             echo "is-production=${{ github.event.inputs.environment == 'production' }}" >> $GITHUB_OUTPUT
-          
+
           # Tag-based deployment
           elif [[ "${{ github.ref }}" =~ mobile-playstore-v([0-9]+\.[0-9]+\.[0-9]+)-demo\. ]]; then
             echo "environment=demo" >> $GITHUB_OUTPUT
@@ -59,19 +59,19 @@ jobs:
             echo "version=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
             echo "build-profile=demo-store" >> $GITHUB_OUTPUT
             echo "is-production=false" >> $GITHUB_OUTPUT
-          
+
           elif [[ "${{ github.ref }}" =~ mobile-playstore-v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
             echo "environment=production" >> $GITHUB_OUTPUT
             echo "track=production" >> $GITHUB_OUTPUT
             echo "version=${BASH_REMATCH[1]}" >> $GITHUB_OUTPUT
             echo "build-profile=production" >> $GITHUB_OUTPUT
             echo "is-production=true" >> $GITHUB_OUTPUT
-          
+
           else
             echo "❌ Invalid trigger. Use workflow_dispatch or tag format: mobile-playstore-v1.2.3"
             exit 1
           fi
-      
+
       - name: Display configuration
         run: |
           echo "🚀 Deployment Configuration:"
@@ -85,30 +85,30 @@ jobs:
     name: Quality Checks
     runs-on: ubuntu-latest
     needs: prepare
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: src/mobile/package-lock.json
-      
+
       - name: Install dependencies
         working-directory: src/mobile
         run: npm ci
-      
+
       - name: Run linter
         working-directory: src/mobile
         run: npm run lint
-      
+
       - name: Run type check
         working-directory: src/mobile
         run: npm run typecheck
-      
+
       - name: Run tests
         working-directory: src/mobile
         run: npm test -- --ci --maxWorkers=2
@@ -120,42 +120,42 @@ jobs:
     environment:
       name: mobile-${{ needs.prepare.outputs.environment }}
       url: https://play.google.com/console/u/0/developers/${{ secrets.GOOGLE_PLAY_DEVELOPER_ID }}/app/${{ secrets.GOOGLE_PLAY_APP_ID }}
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: src/mobile/package-lock.json
-      
+
       - name: Setup Expo and EAS
         uses: expo/expo-github-action@v8
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
-      
+
       - name: Install dependencies
         working-directory: src/mobile
         run: npm ci
-      
+
       - name: Update app version
         working-directory: src/mobile
         run: |
           VERSION="${{ needs.prepare.outputs.version }}"
           echo "📦 Updating version to $VERSION"
-          
+
           # Update version in app.json
           jq ".expo.version = \"$VERSION\"" app.json > app.json.tmp
           mv app.json.tmp app.json
-          
+
           # Display updated version
           echo "✅ Version updated:"
           jq '.expo.version' app.json
-      
+
       - name: Setup Google Play service account
         working-directory: src/mobile
         run: |
@@ -164,14 +164,14 @@ jobs:
           echo '${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}' > secrets/google-play-service-account.json
           chmod 600 secrets/google-play-service-account.json
           echo "✅ Service account configured"
-      
+
       - name: Build Android App Bundle (AAB)
         working-directory: src/mobile
         run: |
           echo "🏗️ Building Android App Bundle..."
           echo "  Profile: ${{ needs.prepare.outputs.build-profile }}"
           echo "  Platform: android"
-          
+
           eas build \
             --profile ${{ needs.prepare.outputs.build-profile }} \
             --platform android \
@@ -179,19 +179,19 @@ jobs:
             --no-wait
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-      
+
       - name: Wait for build completion
         working-directory: src/mobile
         run: |
           echo "⏳ Waiting for build to complete..."
-          
+
           # Poll build status every 60 seconds
           MAX_WAIT=1800  # 30 minutes
           ELAPSED=0
-          
+
           while [ $ELAPSED -lt $MAX_WAIT ]; do
             BUILD_STATUS=$(eas build:list --platform android --limit 1 --json | jq -r '.[0].status')
-            
+
             if [ "$BUILD_STATUS" == "finished" ]; then
               echo "✅ Build completed successfully!"
               break
@@ -204,21 +204,21 @@ jobs:
               ELAPSED=$((ELAPSED + 60))
             fi
           done
-          
+
           if [ $ELAPSED -ge $MAX_WAIT ]; then
             echo "❌ Build timed out after ${MAX_WAIT} seconds"
             exit 1
           fi
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-      
+
       - name: Submit to Google Play Store
         working-directory: src/mobile
         run: |
           echo "📤 Submitting to Google Play Store..."
           echo "  Track: ${{ needs.prepare.outputs.track }}"
           echo "  Service Account: Using GitHub secret"
-          
+
           # Submit using EAS
           eas submit \
             --platform android \
@@ -228,13 +228,13 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           GOOGLE_SERVICE_ACCOUNT_KEY_PATH: ./secrets/google-play-service-account.json
-      
+
       - name: Cleanup secrets
         if: always()
         run: |
           rm -f src/mobile/secrets/google-play-service-account.json
           echo "🧹 Cleaned up secrets"
-      
+
       - name: Create release notes
         id: release-notes
         run: |
@@ -242,37 +242,37 @@ jobs:
           ENV="${{ needs.prepare.outputs.environment }}"
           VERSION="${{ needs.prepare.outputs.version }}"
           TRACK="${{ needs.prepare.outputs.track }}"
-          
+
           cat > release_notes.md << EOF
           # WAOOAW Mobile - $ENV Release
-          
-          **Version**: $VERSION  
-          **Track**: $TRACK  
+
+          **Version**: $VERSION
+          **Track**: $TRACK
           **Build Date**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-          
+
           ## Release Notes
-          
+
           $NOTES
-          
+
           ## Configuration
           - **Environment**: $ENV
           - **Backend**: ${{ needs.prepare.outputs.environment == 'demo' && 'https://waooaw-api-demo-ryvhxvrdna-el.a.run.app' || 'https://api.waooaw.com' }}
           - **Build Profile**: ${{ needs.prepare.outputs.build-profile }}
           - **Distribution**: Google Play Store ($TRACK track)
-          
+
           ## Links
           - [Play Console](https://play.google.com/console)
           - [EAS Builds](https://expo.dev/accounts/waooaw/projects/waooaw-mobile/builds)
-          
+
           ## Next Steps
           1. Monitor crash reports in Play Console
           2. Check user reviews
           3. Monitor backend metrics
           4. Plan next release
           EOF
-          
+
           cat release_notes.md
-      
+
       - name: Create GitHub Release
         if: needs.prepare.outputs.is-production == 'true'
         uses: actions/create-release@v1
@@ -284,7 +284,7 @@ jobs:
           body_path: release_notes.md
           draft: false
           prerelease: false
-      
+
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -299,7 +299,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [prepare, build-and-submit]
     if: always()
-    
+
     steps:
       - name: Notify Slack
         if: always()
@@ -308,18 +308,18 @@ jobs:
           status: ${{ job.status }}
           text: |
             🚀 *Google Play Store Deployment*
-            
+
             *Status*: ${{ job.status == 'success' && '✅ Success' || '❌ Failed' }}
             *Environment*: ${{ needs.prepare.outputs.environment }}
             *Version*: ${{ needs.prepare.outputs.version }}
             *Track*: ${{ needs.prepare.outputs.track }}
-            
+
             *Links*:
             • <https://play.google.com/console|Play Console>
             • <https://expo.dev/accounts/waooaw/projects/waooaw-mobile/builds|EAS Builds>
             • <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|GitHub Actions>
           webhook_url: ${{ secrets.SLACK_WEBHOOK }}
-      
+
       - name: Comment on PR (if applicable)
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
@@ -327,14 +327,14 @@ jobs:
           script: |
             const status = '${{ job.status }}' === 'success' ? '✅' : '❌';
             const body = `${status} **Google Play Store Deployment**
-            
+
             - **Environment**: ${{ needs.prepare.outputs.environment }}
             - **Version**: ${{ needs.prepare.outputs.version }}
             - **Track**: ${{ needs.prepare.outputs.track }}
             - **Status**: ${{ job.status }}
-            
+
             [View in Play Console](https://play.google.com/console) | [View Build](https://expo.dev/accounts/waooaw/projects/waooaw-mobile/builds)`;
-            
+
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
@@ -347,63 +347,63 @@ jobs:
     runs-on: ubuntu-latest
     needs: [prepare, build-and-submit]
     if: failure() && needs.prepare.outputs.is-production == 'true'
-    
+
     steps:
       - name: Create rollback instructions
         run: |
           cat > rollback_plan.md << 'EOF'
           # 🚨 Rollback Plan - Production Deployment Failed
-          
+
           ## Immediate Actions
-          
+
           1. **Halt rollout in Play Console**:
              ```
              - Go to: https://play.google.com/console
              - Navigate to: Release > Production
              - Click "Halt rollout" on the latest release
              ```
-          
+
           2. **Revert to previous version**:
              ```bash
              cd /workspaces/WAOOAW/src/mobile
-             
+
              # Find previous successful build
              eas build:list --platform android --status finished --limit 5
-             
+
              # Submit previous build
              eas submit --platform android --id <PREVIOUS_BUILD_ID>
              ```
-          
+
           3. **Notify users** (if already rolled out):
              - Post in app notification
              - Email to affected users
              - Status page update
-          
+
           ## Investigation
-          
+
           1. Check EAS build logs: https://expo.dev/accounts/waooaw/projects/waooaw-mobile/builds
           2. Check Play Console crash reports
           3. Review backend logs for API errors
           4. Check GitHub Actions logs
-          
+
           ## Prevention
-          
+
           - Run full test suite before production deployment
           - Use internal track for initial testing
           - Gradual rollout (10% → 50% → 100%)
           - Monitor crash-free rate in first 24 hours
-          
+
           EOF
-          
+
           cat rollback_plan.md
-      
+
       - name: Upload rollback plan
         uses: actions/upload-artifact@v4
         with:
           name: rollback-plan-${{ github.run_id }}
           path: rollback_plan.md
           retention-days: 30
-      
+
       - name: Alert team
         uses: 8398a7/action-slack@v3
         with:


### PR DESCRIPTION
Adds manual-triggered workflow for deploying mobile app to Google Play Store.

**Changes:**
- New workflow: mobile-playstore-deploy.yml
- Manual trigger only (workflow_dispatch)
- Supports demo/production environments
- Supports internal/alpha/beta/production tracks
- Includes quality checks, EAS build, Play Store submit

**Required GitHub Secrets:**
- EXPO_TOKEN
- GOOGLE_PLAY_SERVICE_ACCOUNT_JSON