### PR TITLE
fix(gateway): make /auth/google/verify public

### DIFF
--- a/src/Plant/Gateway/middleware/auth.py
+++ b/src/Plant/Gateway/middleware/auth.py
@@ -119,6 +119,8 @@ PUBLIC_ENDPOINTS = [
     "/redoc",
     "/openapi.json",
     "/metrics",
+    # Mobile Google OAuth2 login — caller has no JWT yet
+    "/api/v1/auth/google/verify",
 ]
 
 # Some deployments sit behind a proxy that prefixes application routes with `/api`.
@@ -139,6 +141,13 @@ def _is_public_path(path: str) -> bool:
     normalized = (path or "").rstrip("/") or "/"
     if normalized in {p.rstrip("/") or "/" for p in PUBLIC_ENDPOINTS}:
         return True
+
+    # Some deployments mount the application under a path prefix (e.g. `/api`).
+    # In those cases FastAPI may report a path like `/api/api/v1/auth/google/verify`.
+    # Treat the mobile login endpoint as public even when it is prefixed.
+    if normalized.endswith("/api/v1/auth/google/verify"):
+        return True
+
     # Note: Health endpoints may have nested paths (e.g. /api/health/stream).
     if normalized.startswith("/api/health/") or normalized == "/api/health":
         return True
@@ -543,6 +552,10 @@ class AuthMiddleware(BaseHTTPMiddleware):
         Returns:
             Response object
         """
+        # Always allow CORS preflight requests through.
+        if request.method.upper() == "OPTIONS":
+            return await call_next(request)
+
         if _is_customers_path(request.url.path):
             denial = _validate_registration_key(request)
             if denial is not None:

--- a/src/Plant/Gateway/middleware/budget.py
+++ b/src/Plant/Gateway/middleware/budget.py
@@ -95,8 +95,16 @@ class BudgetGuardMiddleware(BaseHTTPMiddleware):
         """
         Intercept request, check budget, enforce limits, update Redis.
         """
+        # Always allow CORS preflight requests through.
+        if request.method.upper() == "OPTIONS":
+            return await call_next(request)
+
         # Skip public endpoints
         path = request.url.path
+        normalized = (path or "").rstrip("/")
+        if normalized.endswith("/api/v1/auth/google/verify"):
+            return await call_next(request)
+
         if (
             path in ["/health", "/healthz", "/ready", "/metrics", "/docs", "/redoc", "/openapi.json"]
             or path == "/api/health"

--- a/src/Plant/Gateway/middleware/policy.py
+++ b/src/Plant/Gateway/middleware/policy.py
@@ -83,8 +83,16 @@ class PolicyMiddleware(BaseHTTPMiddleware):
         """
         Intercept request, query OPA policies, enforce constitutional rules.
         """
+        # Always allow CORS preflight requests through.
+        if request.method.upper() == "OPTIONS":
+            return await call_next(request)
+
         # Skip public endpoints
         path = request.url.path
+        normalized = (path or "").rstrip("/")
+        if normalized.endswith("/api/v1/auth/google/verify"):
+            return await call_next(request)
+
         if (
             path in ["/health", "/healthz", "/ready", "/metrics", "/docs", "/redoc", "/openapi.json"]
             or path == "/api/health"


### PR DESCRIPTION
Plant Gateway only.

- Allow CORS preflight (OPTIONS) through middleware
- Treat /api/v1/auth/google/verify as public even when mounted under a path prefix

Files:
- src/Plant/Gateway/middleware/auth.py
- src/Plant/Gateway/middleware/policy.py
- src/Plant/Gateway/middleware/budget.py

Safety:
- No changes to CP/PP frontends; auth/policy/budget bypass is limited to OPTIONS + this single auth route.