### PR TITLE
fix(gateway): allow /auth/google/verify without JWT

### DIFF
--- a/src/Plant/Gateway/middleware/auth.py
+++ b/src/Plant/Gateway/middleware/auth.py
@@ -120,6 +120,8 @@ PUBLIC_ENDPOINTS = [
     "/openapi.json",
     "/metrics",
     # Mobile Google OAuth2 login — caller has no JWT yet
+    # (Some deployments expose this at /auth/google/verify, others at /api/v1/auth/google/verify)
+    "/auth/google/verify",
     "/api/v1/auth/google/verify",
 ]
 
@@ -143,9 +145,8 @@ def _is_public_path(path: str) -> bool:
         return True
 
     # Some deployments mount the application under a path prefix (e.g. `/api`).
-    # In those cases FastAPI may report a path like `/api/api/v1/auth/google/verify`.
     # Treat the mobile login endpoint as public even when it is prefixed.
-    if normalized.endswith("/api/v1/auth/google/verify"):
+    if normalized.endswith("/auth/google/verify"):
         return True
 
     # Note: Health endpoints may have nested paths (e.g. /api/health/stream).

--- a/src/Plant/Gateway/middleware/budget.py
+++ b/src/Plant/Gateway/middleware/budget.py
@@ -102,7 +102,7 @@ class BudgetGuardMiddleware(BaseHTTPMiddleware):
         # Skip public endpoints
         path = request.url.path
         normalized = (path or "").rstrip("/")
-        if normalized.endswith("/api/v1/auth/google/verify"):
+        if normalized.endswith("/auth/google/verify"):
             return await call_next(request)
 
         if (

--- a/src/Plant/Gateway/middleware/policy.py
+++ b/src/Plant/Gateway/middleware/policy.py
@@ -90,7 +90,7 @@ class PolicyMiddleware(BaseHTTPMiddleware):
         # Skip public endpoints
         path = request.url.path
         normalized = (path or "").rstrip("/")
-        if normalized.endswith("/api/v1/auth/google/verify"):
+        if normalized.endswith("/auth/google/verify"):
             return await call_next(request)
 
         if (


### PR DESCRIPTION
Plant Gateway only follow-up to #732.

Demo exposes the Google login exchange endpoint at /auth/google/verify (not just /api/v1/auth/google/verify). This PR:
- Treats any path ending with /auth/google/verify as public (covers both /auth/... and /api/v1/auth/... forms)
- Keeps allowing OPTIONS CORS preflight through auth/policy/budget middleware

Files:
- src/Plant/Gateway/middleware/auth.py
- src/Plant/Gateway/middleware/policy.py
- src/Plant/Gateway/middleware/budget.py

Safety:
- No changes to CP/PP apps; bypass is limited to OPTIONS + this single auth route.