### PR TITLE
fix(mobile): set EAS project env for CI builds

### DIFF
--- a/.github/workflows/mobile-playstore-deploy.yml
+++ b/.github/workflows/mobile-playstore-deploy.yml
@@ -284,6 +284,8 @@ jobs:
           set -e
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          EAS_PROJECT_ID: fdb3bbde-a0e0-43f9-bf55-e780ecc563e7
+          EXPO_OWNER: waooaw
 
       - name: Build Android App Bundle (EAS Local)
         if: github.event.inputs.build_method == 'local-eas'
@@ -332,6 +334,8 @@ jobs:
           echo "AAB_PATH=$AAB_FULL_PATH" >> $GITHUB_ENV
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          EAS_PROJECT_ID: fdb3bbde-a0e0-43f9-bf55-e780ecc563e7
+          EXPO_OWNER: waooaw
 
       - name: Wait for Expo build completion
         if: env.BUILD_METHOD == 'expo' && env.BUILD_ID != ''


### PR DESCRIPTION
## What
- Set EAS_PROJECT_ID and EXPO_OWNER in mobile-playstore-deploy workflow

## Why
Avoids 'EAS project not configured' in non-interactive CI builds.