### PR TITLE
fix(mobile): resolve EAS project not configured in CI (root cause fix)

### DIFF
--- a/.github/workflows/mobile-playstore-deploy.yml
+++ b/.github/workflows/mobile-playstore-deploy.yml
@@ -237,6 +237,16 @@ jobs:
           chmod 600 secrets/google-play-service-account.json
           echo "✅ Service account configured"
 
+      - name: Link EAS Project
+        if: github.event.inputs.build_method != 'existing'
+        working-directory: src/mobile
+        run: |
+          echo "🔗 Linking EAS project (required for non-interactive builds)..."
+          eas init --id fdb3bbde-a0e0-43f9-bf55-e780ecc563e7 --non-interactive
+          echo "✅ EAS project linked"
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
       - name: Use Existing Build
         if: github.event.inputs.build_method == 'existing'
         run: |
@@ -284,8 +294,6 @@ jobs:
           set -e
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-          EAS_PROJECT_ID: fdb3bbde-a0e0-43f9-bf55-e780ecc563e7
-          EXPO_OWNER: waooaw
 
       - name: Build Android App Bundle (EAS Local)
         if: github.event.inputs.build_method == 'local-eas'
@@ -334,8 +342,6 @@ jobs:
           echo "AAB_PATH=$AAB_FULL_PATH" >> $GITHUB_ENV
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-          EAS_PROJECT_ID: fdb3bbde-a0e0-43f9-bf55-e780ecc563e7
-          EXPO_OWNER: waooaw
 
       - name: Wait for Expo build completion
         if: env.BUILD_METHOD == 'expo' && env.BUILD_ID != ''

--- a/src/mobile/app.config.js
+++ b/src/mobile/app.config.js
@@ -70,6 +70,10 @@ module.exports = (context = {}) => {
         APP_ENV: runtimeEnv,
         ENVIRONMENT: runtimeEnv,
         BUILD_PROFILE: environment,
+        // Explicitly preserve EAS project ID at canonical location for EAS CLI v18
+        eas: {
+          projectId: expoConfig.projectId || (expoConfig.extra && expoConfig.extra.eas && expoConfig.extra.eas.projectId),
+        },
       },
       // iOS configuration
       ios: {

--- a/src/mobile/app.json
+++ b/src/mobile/app.json
@@ -85,7 +85,10 @@
       "favicon": "./assets/favicon.png"
     },
     "extra": {
-      "APP_ENV": "development"
+      "APP_ENV": "development",
+      "eas": {
+        "projectId": "fdb3bbde-a0e0-43f9-bf55-e780ecc563e7"
+      }
     },
     "plugins": [
       [


### PR DESCRIPTION
## Root cause
EAS CLI v18 (via `eas-version: latest`) requires the project to be explicitly linked per-session in non-interactive mode. Previous attempts (`EAS_PROJECT_ID`/`EXPO_OWNER` env vars) were no-ops — EAS CLI does not recognize those vars.

## What changed

| File | Change |
|---|---|
| `app.json` | Added `expo.extra.eas.projectId` (canonical location EAS CLI v18 reads) |
| `app.config.js` | Explicitly preserve `extra.eas.projectId` in dynamic config |
| `mobile-playstore-deploy.yml` | Added `eas init --id --non-interactive` step before build; removed no-op env vars |

## Why this works
`eas init --id <projectId> --non-interactive` links the project for the current session — exactly what EAS CLI v18 requires before `eas build --non-interactive` can run.