### PR TITLE
fix(mobile): delete sensitive EAS vars before env:push

### DIFF
--- a/.github/workflows/mobile-playstore-deploy.yml
+++ b/.github/workflows/mobile-playstore-deploy.yml
@@ -252,6 +252,11 @@ jobs:
         working-directory: src/mobile
         run: |
           echo "🔐 Syncing build secrets to EAS project..."
+          # Delete existing vars first (may exist as sensitive/secret type from prior runs,
+          # which would block env:push from updating them)
+          for VAR in EXPO_PUBLIC_API_URL_DEMO EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID_DEMO EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID_DEMO EXPO_PUBLIC_OAUTH_REDIRECT_SCHEME_DEMO; do
+            eas env:delete production --variable-name "$VAR" --non-interactive 2>/dev/null || true
+          done
           {
             echo "EXPO_PUBLIC_API_URL_DEMO=${{ secrets.EXPO_PUBLIC_API_URL_DEMO }}"
             echo "EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID_DEMO=${{ secrets.EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID_DEMO }}"

--- a/.github/workflows/test-eas-secrets.yml
+++ b/.github/workflows/test-eas-secrets.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Sync EAS Secrets from GitHub Secrets
         run: |
           echo "🔐 Building secrets env file..."
+          # Delete existing vars first (may exist as sensitive/secret type from prior runs,
+          # which would block env:push from updating them)
+          for VAR in EXPO_PUBLIC_API_URL_DEMO EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID_DEMO EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID_DEMO EXPO_PUBLIC_OAUTH_REDIRECT_SCHEME_DEMO; do
+            eas env:delete production --variable-name "$VAR" --non-interactive 2>/dev/null || true
+          done
           {
             echo "EXPO_PUBLIC_API_URL_DEMO=${{ secrets.EXPO_PUBLIC_API_URL_DEMO }}"
             echo "EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID_DEMO=${{ secrets.EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID_DEMO }}"


### PR DESCRIPTION
## Root Cause

PR #745 used `eas secret:push` which created the 4 DEMO vars as **sensitive/secret type** in EAS. PR #747 switched to `eas env:push`, but EAS enforces:

> `You cannot change a secret variable to a non-secret variable.`

So `env:push --force` still fails when it tries to overwrite a sensitive var with a plain one.

## Fix

Before each `env:push`, delete the 4 vars (with `|| true` so it's safe on first run when nothing exists yet):

```bash
for VAR in EXPO_PUBLIC_API_URL_DEMO EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID_DEMO ...; do
  eas env:delete production --variable-name "$VAR" --non-interactive 2>/dev/null || true
done
eas env:push production --path /tmp/eas-secrets.env --force
```

Applied to both `mobile-playstore-deploy.yml` and `test-eas-secrets.yml`.