### PR TITLE
fix(ci): strip non-JSON EAS CLI output before jq in wait/download steps

### DIFF
--- a/.github/workflows/mobile-playstore-deploy.yml
+++ b/.github/workflows/mobile-playstore-deploy.yml
@@ -382,12 +382,13 @@ jobs:
           SLEEP_INTERVAL=30
 
           while [ $ELAPSED -lt $MAX_WAIT ]; do
-            RAW_INFO=$(eas build:view "$BUILD_ID" --json --non-interactive 2>&1 || echo "{}")
-            # Strip non-JSON lines before the first { or [
-            BUILD_INFO=$(echo "$RAW_INFO" | awk '/^[{\[]/{found=1} found{print}' | head -c 65536)
+            RAW_INFO=$(eas build:view "$BUILD_ID" --json 2>&1 || true)
+            # Strip spinner/non-JSON lines before the first { or [
+            BUILD_INFO=$(echo "$RAW_INFO" | awk '/^[{\[]/{found=1} found{print}')
 
-            if echo "$BUILD_INFO" | jq empty 2>/dev/null; then
-              BUILD_STATUS=$(echo "$BUILD_INFO" | jq -r '.status // "unknown"' | tr '[:upper:]' '[:lower:]')
+            if [ -n "$BUILD_INFO" ] && echo "$BUILD_INFO" | jq empty 2>/dev/null; then
+              BUILD_STATUS=$(echo "$BUILD_INFO" | jq -r 'if type=="array" then (.[0].status // "unknown") else (.status // "unknown") end' | tr '[:upper:]' '[:lower:]')
+              BUILD_STATUS=${BUILD_STATUS:-unknown}
 
               echo "⏳ Build $BUILD_ID status: $BUILD_STATUS (${ELAPSED}s elapsed)"
 
@@ -422,7 +423,7 @@ jobs:
         run: |
           echo "📥 Downloading AAB from Expo..."
 
-          RAW_INFO=$(eas build:view "$BUILD_ID" --json --non-interactive)
+          RAW_INFO=$(eas build:view "$BUILD_ID" --json 2>&1)
           BUILD_INFO=$(echo "$RAW_INFO" | awk '/^[{\[]/{found=1} found{print}')
           AAB_URL=$(echo "$BUILD_INFO" | jq -r '.artifacts.buildUrl // empty')
 


### PR DESCRIPTION
## Problem
The 'Wait for Expo build completion' step loops forever (prints 'Waiting for build status to be available' until 30-min timeout) because `eas build:view --json` outputs non-JSON lines before the JSON object. `jq empty` fails on mixed output, so `BUILD_STATUS` is never evaluated.

Same issue also affects the 'Download AAB from Expo' step.

## Fix
Use `awk` to strip everything before the first `{` or `[` in EAS output before piping to `jq` — in both the wait loop and download step.