### PR TITLE
feat(devcontainer): re-enable GitHub Copilot extensions and settings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,6 @@
       "moby": false
     }
   },
-  "postAttachCommand": "bash -lc 'code --uninstall-extension GitHub.copilot >/dev/null 2>&1 || true; code --uninstall-extension GitHub.copilot-chat >/dev/null 2>&1 || true; code --uninstall-extension GitHub.vscode-pull-request-github >/dev/null 2>&1 || true'",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -16,11 +15,7 @@
       ],
       "settings": {
         "python.defaultInterpreterPath": "/usr/local/bin/python3",
-        "python.testing.pytestEnabled": true,
-        "github.copilot.enable": {
-          "*": false
-        },
-        "github.copilot.editor.enableAutoCompletions": false
+        "python.testing.pytestEnabled": true
       }
     }
   },


### PR DESCRIPTION
## Summary

Re-enables GitHub Copilot in the devcontainer after confirming the integration defect is resolved.

## Changes

- Removed `postAttachCommand` that was force-uninstalling `GitHub.copilot`, `GitHub.copilot-chat`, and `GitHub.vscode-pull-request-github` on each attach
- Removed settings that disabled Copilot (`github.copilot.enable: { "*": false }` and `github.copilot.editor.enableAutoCompletions: false`)

## Why

These were added as a temporary workaround during a Copilot integration defect investigation. The integration is now stable and the workaround is no longer needed.

## Rollback Plan

If issues resurface, revert this PR — the original disable/uninstall code is preserved in git history.