### PR TITLE
fix(cp): harden dma theme runtime path

### DIFF
--- a/src/CP/BackEnd/api/digital_marketing_activation.py
+++ b/src/CP/BackEnd/api/digital_marketing_activation.py
@@ -48,9 +48,31 @@ def _unwrap_gateway_error_detail(detail: Any) -> Any:
     return detail
 
 
+def _sanitize_upstream_failure_detail(detail: Any) -> str:
+    unwrapped = _unwrap_gateway_error_detail(detail)
+    if isinstance(unwrapped, dict):
+        candidate = str(
+            unwrapped.get("detail")
+            or unwrapped.get("message")
+            or unwrapped.get("error")
+            or ""
+        ).strip()
+    else:
+        candidate = str(unwrapped or "").strip()
+
+    lowered = candidate.lower()
+    if not candidate:
+        return "Digital marketing activation upstream failure"
+    if any(token in lowered for token in ["traceback", "xai_api_key", "api key", "sk-", "bearer ", "password", "secret"]):
+        return "UPSTREAM_ERROR"
+    if lowered in {"internal server error", "upstream_error"}:
+        return "Digital marketing activation upstream failure"
+    return candidate[:240]
+
+
 def _raise_for_gateway_response(resp: Any) -> None:
     if resp.status_code >= 500:
-        raise HTTPException(status_code=503, detail="UPSTREAM_ERROR")
+        raise HTTPException(status_code=503, detail=_sanitize_upstream_failure_detail(resp.json))
     if resp.status_code >= 400:
         raise HTTPException(status_code=resp.status_code, detail=_unwrap_gateway_error_detail(resp.json))
 

--- a/src/CP/BackEnd/tests/test_digital_marketing_activation_proxy.py
+++ b/src/CP/BackEnd/tests/test_digital_marketing_activation_proxy.py
@@ -166,3 +166,24 @@ def test_generate_theme_plan_proxy_surfaces_upstream_failure_without_secret_leak
     assert response.json()["detail"] == "UPSTREAM_ERROR"
     assert "sk-" not in response.text
     app.dependency_overrides.clear()
+
+
+@pytest.mark.unit
+def test_generate_theme_plan_proxy_surfaces_safe_upstream_message(client, auth_headers, monkeypatch):
+    monkeypatch.setenv("PLANT_GATEWAY_URL", "http://plant-test:8000")
+    payload = {"detail": "Digital marketing theme generation failed upstream"}
+    from api.digital_marketing_activation import get_plant_gateway_client
+    from main import app
+
+    fake = _FakePlantClient(response_status=500, response_json=payload)
+    app.dependency_overrides[get_plant_gateway_client] = lambda: fake
+
+    response = client.post(
+        "/api/cp/digital-marketing-activation/HAI-1/generate-theme-plan",
+        headers=auth_headers,
+        json={},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Digital marketing theme generation failed upstream"
+    app.dependency_overrides.clear()

--- a/src/Plant/BackEnd/api/v1/digital_marketing_activation.py
+++ b/src/Plant/BackEnd/api/v1/digital_marketing_activation.py
@@ -414,6 +414,20 @@ def _normalize_derived_themes(raw_derived: Any) -> list[dict[str, Any]]:
     return normalized
 
 
+def _sanitize_theme_value(value: Any, fallback: str = "Digital marketing activation plan") -> str:
+    candidate = str(value or "").strip()
+    if len(candidate) < 3:
+        return fallback
+
+    if candidate in {"{", "}", "[", "]", "{}", "[]"}:
+        return fallback
+
+    if candidate.startswith("{") or candidate.startswith("["):
+        return fallback
+
+    return candidate[:160]
+
+
 def _parse_theme_plan(raw_text: str) -> tuple[str, list[dict[str, Any]]]:
     cleaned = str(raw_text or "").strip()
     if not cleaned:
@@ -421,12 +435,12 @@ def _parse_theme_plan(raw_text: str) -> tuple[str, list[dict[str, Any]]]:
     try:
         payload = json.loads(cleaned)
     except json.JSONDecodeError:
-        return cleaned.splitlines()[0][:120] or "Digital marketing activation plan", []
+        return _sanitize_theme_value(cleaned.splitlines()[0][:120]), []
 
     if not isinstance(payload, dict):
         return "Digital marketing activation plan", []
 
-    master_theme = str(payload.get("master_theme") or payload.get("theme") or "Digital marketing activation plan").strip()
+    master_theme = _sanitize_theme_value(payload.get("master_theme") or payload.get("theme"))
     return master_theme or "Digital marketing activation plan", _normalize_derived_themes(payload.get("derived_themes"))
 
 
@@ -460,10 +474,10 @@ def _parse_theme_workshop_response(
         workshop = _normalize_strategy_workshop(existing_workshop, workspace)
         if pending_input:
             workshop["messages"] = [*workshop["messages"], {"role": "user", "content": pending_input}]
-        assistant_message = master_theme or fallback_message
+        assistant_message = _sanitize_theme_value(master_theme, fallback_message)
         workshop["assistant_message"] = assistant_message
         workshop["status"] = "approval_ready" if derived_themes else "discovery"
-        workshop["checkpoint_summary"] = master_theme or "The core strategy is taking shape, but it still needs one stronger decision."
+        workshop["checkpoint_summary"] = _sanitize_theme_value(master_theme, "The core strategy is taking shape, but it still needs one stronger decision.")
         workshop["current_focus_question"] = ""
         workshop["next_step_options"] = ["Approve this direction", "Sharpen the audience", "Suggest a different first angle"]
         workshop["time_saving_note"] = "I have collapsed your earlier answers into one working direction so we do not keep restating the same inputs."
@@ -473,9 +487,12 @@ def _parse_theme_workshop_response(
     if not isinstance(payload, dict):
         return _parse_theme_workshop_response("", workspace=workspace, existing_workshop=existing_workshop, pending_input=pending_input)
 
-    master_theme = str(payload.get("master_theme") or payload.get("theme") or existing_workshop.get("master_theme") or "Digital marketing activation plan").strip()
+    master_theme = _sanitize_theme_value(
+        payload.get("master_theme") or payload.get("theme") or existing_workshop.get("master_theme")
+    )
     derived_themes = _normalize_derived_themes(payload.get("derived_themes"))
     assistant_message = str(payload.get("assistant_message") or "").strip() or (master_theme if derived_themes else fallback_message)
+    assistant_message = _sanitize_theme_value(assistant_message, fallback_message)
     workshop = _normalize_strategy_workshop(payload.get("strategy_workshop") or payload, workspace)
 
     if pending_input:
@@ -588,6 +605,8 @@ async def _persist_theme_plan_to_campaign(
         },
         "schedule": dict(campaign_setup.get("schedule") or {}),
     }
+    safe_master_theme = _sanitize_theme_value(master_theme)
+    activation_payload["theme_plan"]["master_theme"] = safe_master_theme
     brief = campaigns_module.build_campaign_brief_from_activation_payload(activation_payload)
     cost_estimate = estimate_cost(brief, model_used="grok-3-latest")
 
@@ -879,9 +898,11 @@ async def generate_theme_plan(
     if db is not None:
         await db.commit()
 
+    safe_master_theme = _sanitize_theme_value(master_theme)
+
     return ThemePlanResponse(
         campaign_id=campaign_id,
-        master_theme=master_theme,
+        master_theme=safe_master_theme,
         derived_themes=derived_themes,
         workspace=persisted_workspace,
     )

--- a/src/Plant/BackEnd/tests/unit/test_digital_marketing_theme_generation_api.py
+++ b/src/Plant/BackEnd/tests/unit/test_digital_marketing_theme_generation_api.py
@@ -144,6 +144,31 @@ def test_generate_theme_plan_reuses_existing_draft_campaign(test_client, monkeyp
 
 
 @pytest.mark.unit
+def test_generate_theme_plan_falls_back_when_model_returns_json_fragment(test_client, monkeypatch):
+    monkeypatch.setenv("PAYMENTS_MODE", "coupon")
+    monkeypatch.setenv("PERSISTENCE_MODE", "memory")
+    monkeypatch.setenv("CAMPAIGN_PERSISTENCE_MODE", "memory")
+
+    hired_instance_id = _create_marketing_hire(test_client, customer_id="cust-dma-json-fragment")
+
+    import api.v1.digital_marketing_activation as dma_module
+
+    monkeypatch.setattr(dma_module, "get_grok_client", lambda: object())
+    monkeypatch.setattr(dma_module, "grok_complete", lambda *args, **kwargs: "{")
+
+    response = test_client.post(
+        f"/api/v1/digital-marketing-activation/{hired_instance_id}/generate-theme-plan",
+        headers={"Authorization": "Bearer test-token"},
+        json={"campaign_setup": {"schedule": {"start_date": "2026-03-22", "posts_per_week": 2}}},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["master_theme"] == "Digital marketing activation plan"
+    assert body["workspace"]["campaign_setup"]["master_theme"] == "Digital marketing activation plan"
+
+
+@pytest.mark.unit
 def test_theme_workshop_prompt_requires_thread_aware_brief_consultative_replies():
     import api.v1.digital_marketing_activation as dma_module
 


### PR DESCRIPTION
## Summary
- sanitize malformed DMA theme values before campaign brief persistence so truncated model output like { no longer crashes Plant theme generation
- keep the persisted workspace and response aligned to the sanitized fallback theme value
- surface a safe upstream failure detail from the CP DMA proxy instead of always collapsing backend 5xx responses to UPSTREAM_ERROR
- add Plant regression coverage for malformed JSON fragment output and CP proxy coverage for safe upstream 5xx detail propagation

## Verification
- docker compose -f docker-compose.test.yml run --rm -T plant-backend-test --no-cov tests/unit/test_digital_marketing_theme_generation_api.py
  Result: 7 passed
- docker compose -f docker-compose.test.yml run --rm -T cp-backend-test --no-cov tests/test_digital_marketing_activation_proxy.py
  Result: 5 passed

## Notes
- running the same narrow files without --no-cov hits each service repo coverage threshold, so targeted functional verification was rerun without coverage enforcement
- this fix addresses the confirmed Plant runtime crash from malformed theme output; the separate Redis timeout and missing brand_voices relation seen in logs remain independent follow-ups