### PR TITLE
fix(dma): wire chat approval/generation intent to inline draft creation

### DIFF
--- a/src/CP/FrontEnd/src/components/DigitalMarketingActivationWizard.tsx
+++ b/src/CP/FrontEnd/src/components/DigitalMarketingActivationWizard.tsx
@@ -1145,7 +1145,7 @@ export function DigitalMarketingActivationWizard({
     })
   }
 
-  const applyThemePlanResponse = (response: { workspace?: unknown; master_theme?: string; derived_themes?: DigitalMarketingDerivedTheme[] }) => {
+  const applyThemePlanResponse = (response: { workspace?: unknown; master_theme?: string; derived_themes?: DigitalMarketingDerivedTheme[]; auto_generated_draft?: unknown }) => {
     const responseWorkspace = ((response.workspace as any)?.workspace || response.workspace || {}) as DigitalMarketingActivationResponse['workspace']
     const nextWorkspace = {
       ...(activation?.workspace || {}),
@@ -1168,6 +1168,14 @@ export function DigitalMarketingActivationWizard({
     setStrategyWorkshop(nextWorkshop)
     setStrategySummary(nextWorkshop.summary || {})
     setStrategyReply('')
+    // If the agent generated a draft inline (from chat approval/generation intent), surface it
+    if (response.auto_generated_draft && typeof response.auto_generated_draft === 'object') {
+      const batch = response.auto_generated_draft as DraftBatch
+      setGeneratedBatch(batch)
+      setDraftPosts((batch.posts || []).filter((p) => p.channel === 'youtube'))
+      setPostActionStatus({})
+      setPostPublishReceipts({})
+    }
   }
 
   const generateThemePlan = async (overrideReply?: string) => {

--- a/src/Plant/BackEnd/api/v1/digital_marketing_activation.py
+++ b/src/Plant/BackEnd/api/v1/digital_marketing_activation.py
@@ -2,15 +2,22 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from datetime import datetime, timezone
-from typing import Any, Optional
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
+from uuid import uuid4
 
 from fastapi import Depends, Header, HTTPException
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from agent_mold.skills.content_models import Campaign, CampaignWorkflowState, DailyThemeItem, estimate_cost
+from agent_mold.skills.executor import execute_marketing_multichannel_v1
 from agent_mold.skills.grok_client import GrokClientError, get_grok_client, grok_complete
+from agent_mold.skills.loader import load_playbook
+from agent_mold.skills.playbook import ArtifactRequest, ArtifactType, ChannelName, SkillExecutionInput
 from api.v1 import campaigns as campaigns_module
 from api.v1 import hired_agents_simple
 from api.v1.platform_connections import get_connected_platform_connection
@@ -18,6 +25,7 @@ from core.logging import PiiMaskingFilter
 from core.routing import waooaw_router
 from repositories.campaign_repository import CampaignRepository
 from repositories.hired_agent_repository import HiredAgentRepository
+from services.draft_batches import DatabaseDraftBatchStore, DraftBatchRecord, DraftPostRecord
 
 
 router = waooaw_router(prefix="/hired-agents", tags=["digital-marketing-activation"])
@@ -71,6 +79,155 @@ class ThemePlanResponse(BaseModel):
     master_theme: str
     derived_themes: list[dict[str, Any]] = Field(default_factory=list)
     workspace: dict[str, Any] = Field(default_factory=dict)
+    # Populated when the customer's message triggers content generation directly from chat
+    auto_generated_draft: Optional[dict[str, Any]] = None
+
+
+@lru_cache(maxsize=1)
+def _dma_playbook():
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "agent_mold"
+        / "playbooks"
+        / "marketing"
+        / "multichannel_post_v1.md"
+    )
+    return load_playbook(path)
+
+
+# ---------------------------------------------------------------------------
+# Intent detection — recognises natural-language approval / generation signals
+# ---------------------------------------------------------------------------
+
+_APPROVAL_PATTERNS = re.compile(
+    r"\b(approve[ds]?|yes|confirm(s|ed)?|go ahead|start|proceed|lock.?it|lock.?in|looks? good|all set|"
+    r"let'?s go|move.?on|next step|finalize|finalise|done|ready|great|perfect|sounds? good|agreed)\b",
+    re.IGNORECASE,
+)
+
+_ARTIFACT_KEYWORDS: List[Tuple[str, ArtifactType]] = [
+    (r"\b(table|spreadsheet|schedule|plan|calendar|list|comparison|checklist)\b", ArtifactType.TABLE),
+    (r"\b(image|picture|photo|visual|graphic|thumbnail|banner|design)\b", ArtifactType.IMAGE),
+    (r"\b(video|clip|reel|short|film|recording)\b", ArtifactType.VIDEO),
+    (r"\b(audio|voice|narration|podcast|sound)\b", ArtifactType.AUDIO),
+    (r"\b(video.?audio|narrated.?video|video.?with.?(voice|narration|audio))\b", ArtifactType.VIDEO_AUDIO),
+]
+
+_GENERATE_VERBS = re.compile(
+    r"\b(show|give|create|generate|make|build|produce|draft|write|prepare|get)\b",
+    re.IGNORECASE,
+)
+
+
+def _detect_generation_intent(
+    pending_input: str,
+    workshop_status: str,
+) -> Tuple[bool, List[ArtifactType]]:
+    """Return (should_generate_draft, artifact_types_requested).
+
+    Fires when:
+    - customer explicitly requests an artifact type (table/image/video etc.), OR
+    - customer sends an approval signal AND the workshop is already approval_ready or approved.
+    """
+    text = pending_input.strip()
+    if not text:
+        return False, []
+
+    # Detect explicit artifact mention
+    requested_artifact_types: List[ArtifactType] = []
+    for pattern, artifact_type in _ARTIFACT_KEYWORDS:
+        if re.search(pattern, text, re.IGNORECASE):
+            requested_artifact_types.append(artifact_type)
+
+    has_generate_verb = bool(_GENERATE_VERBS.search(text))
+    has_approval_signal = bool(_APPROVAL_PATTERNS.search(text))
+
+    # Explicit "show me table/video/image" — always generate
+    if requested_artifact_types and has_generate_verb:
+        return True, requested_artifact_types
+
+    # Pure approval signal when strategy is ready — generate table by default
+    if has_approval_signal and workshop_status in {"approval_ready", "approved"}:
+        # Default to table if no specific artifact mentioned
+        return True, requested_artifact_types or [ArtifactType.TABLE]
+
+    # Conversational mention of an artifact type with approval signal
+    if requested_artifact_types and has_approval_signal:
+        return True, requested_artifact_types
+
+    return False, []
+
+
+async def _build_auto_draft(
+    *,
+    record: hired_agents_simple._HiredAgentRecord,
+    workspace: dict[str, Any],
+    master_theme: str,
+    campaign_id: str | None,
+    artifact_types: List[ArtifactType],
+    db: AsyncSession | None,
+) -> dict[str, Any]:
+    """Build and persist a draft batch inline from the chat handler. Returns the serialisable batch dict."""
+    playbook = _dma_playbook()
+    brand_name = str(workspace.get("brand_name") or record.nickname or "").strip()
+    location = str(workspace.get("location") or "").strip()
+    language = str(workspace.get("primary_language") or "en").strip()
+
+    subject = master_theme or brand_name or "the approved content plan"
+    requested_artifacts = [
+        ArtifactRequest(
+            artifact_type=art,
+            prompt=f"Create a {art.value.replace('_', ' ')} asset for: {subject}",
+            metadata={"source": "dma_chat_intent", "channel": "youtube"},
+        )
+        for art in artifact_types
+    ]
+
+    result = execute_marketing_multichannel_v1(
+        playbook,
+        SkillExecutionInput(
+            theme=master_theme or brand_name,
+            brand_name=brand_name,
+            offer=None,
+            location=location or None,
+            audience=None,
+            tone=None,
+            language=language,
+            channels=[ChannelName.YOUTUBE],
+            requested_artifacts=requested_artifacts,
+        ),
+    )
+
+    batch_id = str(uuid4())
+    posts = [
+        DraftPostRecord(
+            post_id=str(uuid4()),
+            channel=v.channel,
+            text=v.text,
+            hashtags=v.hashtags,
+        )
+        for v in result.output.variants
+    ]
+
+    batch = DraftBatchRecord(
+        batch_id=batch_id,
+        agent_id=str(record.agent_id or ""),
+        hired_instance_id=record.hired_instance_id,
+        campaign_id=campaign_id,
+        customer_id=str(record.customer_id or "") if record.customer_id else None,
+        theme=result.output.canonical.theme,
+        brand_name=brand_name,
+        brief_summary=None,
+        created_at=datetime.utcnow(),
+        posts=posts,
+    )
+
+    if db is not None:
+        store = DatabaseDraftBatchStore(db)
+        await store.save_batch(batch)
+        # Caller commits after this returns
+
+    return batch.model_dump(mode="json")
 
 
 def _workspace_from_config(config: dict[str, Any] | None) -> dict[str, Any]:
@@ -928,11 +1085,49 @@ async def generate_theme_plan(
     if db is not None:
         await db.commit()
 
+    # --- Intent detection: did the customer ask to generate content? ---
+    auto_draft: dict[str, Any] | None = None
+    should_generate, artifact_types = _detect_generation_intent(
+        pending_input,
+        workshop_status=strategy_workshop.get("status", "discovery"),
+    )
+    if should_generate and master_theme:
+        try:
+            auto_draft = await _build_auto_draft(
+                record=record,
+                workspace=persisted_workspace,
+                master_theme=master_theme,
+                campaign_id=campaign_id,
+                artifact_types=artifact_types,
+                db=db,
+            )
+            if db is not None:
+                await db.commit()
+            # Mark workshop as approved since content was generated
+            persisted_workspace = {
+                **persisted_workspace,
+                "campaign_setup": {
+                    **persisted_workspace.get("campaign_setup", {}),
+                    "strategy_workshop": {
+                        **persisted_workspace.get("campaign_setup", {}).get("strategy_workshop", {}),
+                        "status": "approved",
+                    },
+                },
+            }
+            logger.info(
+                "Auto-generated draft from chat intent for hired_instance_id=%s artifact_types=%s",
+                hired_instance_id,
+                [a.value for a in artifact_types],
+            )
+        except Exception as exc:
+            logger.warning("Auto-draft generation failed: %s", exc)
+
     return ThemePlanResponse(
         campaign_id=campaign_id,
         master_theme=master_theme,
         derived_themes=derived_themes,
         workspace=persisted_workspace,
+        auto_generated_draft=auto_draft,
     )
 
 

--- a/src/Plant/BackEnd/tests/test_dma_chat_intent.py
+++ b/src/Plant/BackEnd/tests/test_dma_chat_intent.py
@@ -1,0 +1,139 @@
+"""Unit tests for DMA chat intent detection (fix/dma-chat-intent-to-action).
+
+Tests cover _detect_generation_intent in digital_marketing_activation.py.
+"""
+from __future__ import annotations
+
+import pytest
+
+from api.v1.digital_marketing_activation import _detect_generation_intent
+from agent_mold.skills.playbook import ArtifactType
+
+
+# ---------------------------------------------------------------------------
+# Approval-signal only (workshop is approval_ready)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("phrase", [
+    "yes",
+    "approved",
+    "looks good",
+    "go ahead",
+    "all set",
+    "proceed",
+    "sounds good",
+    "let's go",
+    "Yes, let's go",
+    "Looks good to me!",
+    "Great, proceed.",
+    "Agreed.",
+    "Perfect.",
+])
+def test_approval_signal_when_approval_ready_triggers_table(phrase: str) -> None:
+    should_gen, arts = _detect_generation_intent(phrase, "approval_ready")
+    assert should_gen is True
+    assert ArtifactType.TABLE in arts
+
+
+@pytest.mark.parametrize("phrase", [
+    "yes",
+    "confirms",
+    "go ahead",
+])
+def test_approval_signal_when_approved_triggers_table(phrase: str) -> None:
+    should_gen, arts = _detect_generation_intent(phrase, "approved")
+    assert should_gen is True
+    assert ArtifactType.TABLE in arts
+
+
+def test_approval_does_not_trigger_when_workshop_not_ready() -> None:
+    should_gen, _ = _detect_generation_intent("yes, looks good", "in_progress")
+    assert should_gen is False
+
+
+def test_empty_input_never_triggers() -> None:
+    should_gen, arts = _detect_generation_intent("", "approval_ready")
+    assert should_gen is False
+    assert arts == []
+
+
+def test_whitespace_only_never_triggers() -> None:
+    should_gen, arts = _detect_generation_intent("   ", "approval_ready")
+    assert should_gen is False
+    assert arts == []
+
+
+# ---------------------------------------------------------------------------
+# Verb + artifact type — always triggers regardless of workshop status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("phrase,expected_type", [
+    ("show me a table", ArtifactType.TABLE),
+    ("create a content calendar", ArtifactType.TABLE),
+    ("generate a table", ArtifactType.TABLE),
+    ("give me a schedule", ArtifactType.TABLE),
+    ("show me an image", ArtifactType.IMAGE),
+    ("create a thumbnail", ArtifactType.IMAGE),
+    ("generate a video", ArtifactType.VIDEO),
+    ("make a reel", ArtifactType.VIDEO),
+    ("produce a clip", ArtifactType.VIDEO),
+    ("create audio narration", ArtifactType.AUDIO),
+    ("make a podcast", ArtifactType.AUDIO),
+    ("create a narrated video", ArtifactType.VIDEO_AUDIO),
+    ("generate video with audio", ArtifactType.VIDEO_AUDIO),
+])
+def test_verb_plus_artifact_triggers(phrase: str, expected_type: ArtifactType) -> None:
+    should_gen, arts = _detect_generation_intent(phrase, "in_progress")
+    assert should_gen is True
+    assert expected_type in arts
+
+
+def test_artifact_mention_without_verb_and_no_approval() -> None:
+    """Pure noun mention without action verb and no approval should not trigger."""
+    should_gen, _ = _detect_generation_intent("I was thinking about a table", "in_progress")
+    assert should_gen is False
+
+
+def test_artifact_mention_with_approval_signal_triggers() -> None:
+    """Artifact + approval signal (even without explicit generate verb) should trigger."""
+    should_gen, arts = _detect_generation_intent("looks good, show me the video", "in_progress")
+    assert should_gen is True
+    assert ArtifactType.VIDEO in arts
+
+
+# ---------------------------------------------------------------------------
+# Multiple artifact types in one message
+# ---------------------------------------------------------------------------
+
+
+def test_multi_artifact_types() -> None:
+    should_gen, arts = _detect_generation_intent("create an image and a video for me", "in_progress")
+    assert should_gen is True
+    assert ArtifactType.IMAGE in arts
+    assert ArtifactType.VIDEO in arts
+
+
+def test_approval_with_explicit_artifact_uses_explicit_not_default_table() -> None:
+    should_gen, arts = _detect_generation_intent("yes, generate a video", "approval_ready")
+    assert should_gen is True
+    assert ArtifactType.VIDEO in arts
+    # TABLE should not be the default when an explicit artifact type is present
+    assert ArtifactType.TABLE not in arts
+
+
+# ---------------------------------------------------------------------------
+# Case-insensitivity
+# ---------------------------------------------------------------------------
+
+
+def test_case_insensitive_verb() -> None:
+    should_gen, arts = _detect_generation_intent("SHOW ME A TABLE", "in_progress")
+    assert should_gen is True
+    assert ArtifactType.TABLE in arts
+
+
+def test_case_insensitive_approval() -> None:
+    should_gen, arts = _detect_generation_intent("YES", "approval_ready")
+    assert should_gen is True


### PR DESCRIPTION
## Problem
The DMA chat was stuck in an endless strategy-confirmation loop. Saying "yes", "looks good", or "show me a table" would just trigger another round of strategy questions — never producing any actual content.

## Root Cause
`generate_theme_plan` always ran the strategy LLM regardless of what the customer typed. There was no code that detected approval or generation intent and routed to draft creation.

## Solution

### Plant BackEnd (`digital_marketing_activation.py`)
- **`_detect_generation_intent(pending_input, workshop_status)`** — fires when:
  - Customer uses a generation verb + artifact noun: *"show me a table"*, *"generate a video"*, *"create a thumbnail"*
  - Customer sends an approval signal (*"yes"*, *"go ahead"*, *"looks good"*, *"confirmed"*, *"proceed"*, *"sounds good"*, *"perfect"*, …) **and** the workshop is `approval_ready` or `approved`
- **`_build_auto_draft(...)`** — calls `execute_marketing_multichannel_v1` + persists a `DraftBatchRecord`; returns serialisable dict
- **`ThemePlanResponse.auto_generated_draft`** — new optional field carries the batch back through CP (thin proxy passes it through unchanged)
- Regex patterns: `_APPROVAL_PATTERNS` + `_ARTIFACT_KEYWORDS` + `_GENERATE_VERBS`

### CP FrontEnd (`DigitalMarketingActivationWizard.tsx`)
- **`applyThemePlanResponse`** — now accepts `auto_generated_draft?` and when present calls `setGeneratedBatch` + `setDraftPosts`, populating the draft panel automatically from a chat message

### Tests (`tests/test_dma_chat_intent.py`)
- 38 unit tests covering approval signals, verb+artifact combos, multi-artifact, edge cases (empty input, wrong workshop state), case insensitivity

## What stays "queued" (known limitation)
Only the `table` artifact type resolves to real LLM content immediately. `image`, `video`, `audio`, and `video_audio` set artifact status as `queued` — they require external generation APIs (DALL-E, video gen, TTS) not yet wired. The infrastructure for queued jobs was added in PR #1035.

## Test Results
- Plant backend: **38 passed, 0 failed**
- CP frontend: **49 passed, 0 failed**