### PR TITLE
fix(dma): add 'tabular' to artifact intent keywords

### DIFF
--- a/src/Plant/BackEnd/api/v1/digital_marketing_activation.py
+++ b/src/Plant/BackEnd/api/v1/digital_marketing_activation.py
@@ -106,7 +106,7 @@ _APPROVAL_PATTERNS = re.compile(
 )
 
 _ARTIFACT_KEYWORDS: List[Tuple[str, ArtifactType]] = [
-    (r"\b(table|spreadsheet|schedule|plan|calendar|list|comparison|checklist)\b", ArtifactType.TABLE),
+    (r"\b(table|tabular|tabulate|spreadsheet|schedule|plan|calendar|list|comparison|checklist)\b", ArtifactType.TABLE),
     (r"\b(image|picture|photo|visual|graphic|thumbnail|banner|design)\b", ArtifactType.IMAGE),
     (r"\b(video|clip|reel|short|film|recording)\b", ArtifactType.VIDEO),
     (r"\b(audio|voice|narration|podcast|sound)\b", ArtifactType.AUDIO),

--- a/src/Plant/BackEnd/tests/test_dma_chat_intent.py
+++ b/src/Plant/BackEnd/tests/test_dma_chat_intent.py
@@ -74,6 +74,8 @@ def test_whitespace_only_never_triggers() -> None:
     ("create a content calendar", ArtifactType.TABLE),
     ("generate a table", ArtifactType.TABLE),
     ("give me a schedule", ArtifactType.TABLE),
+    # "tabular" must fire — real user phrasing confirmed in prod logs (Apr 2026)
+    ("give me themes for April 2026, in tabular format", ArtifactType.TABLE),
     ("show me an image", ArtifactType.IMAGE),
     ("create a thumbnail", ArtifactType.IMAGE),
     ("generate a video", ArtifactType.VIDEO),


### PR DESCRIPTION
## Root Cause

`_ARTIFACT_KEYWORDS` TABLE pattern used `\b(table|...)\b` which does **NOT** match `tabular` — word boundary fails because `tabular` is not terminated by a non-word character after `table`.

## Evidence from GCP Cloud Run logs (plant-backend-demo, 2026-04-10T11:19:50)

```
POST /api/v1/digital-marketing-activation/HAI-9c2878bd.../generate-theme-plan 200 OK
Generated DMA theme plan for hired_instance_id=HAI-9c2878bd...
```

DB query immediately after showed **0 rows** in `marketing_draft_posts` — despite the endpoint returning 200 OK. The LLM said "Check the table" in its text but `auto_generated_draft` was `None` and no `[DRAFT_POSTS:]` marker was injected into the chat.

## RCA breakdown

| Stage | What happened |
|---|---|
| User message | "give me themes for April 2026, in **tabular format**" |
| `_detect_generation_intent` | `requested_artifact_types = []` — `\btable\b` doesn't match `tabular` |
| Result | `should_generate = False` → `_build_auto_draft()` never called |
| DB | 0 rows written to `marketing_draft_posts` |
| Chat | LLM text says "check the table"; no `[DRAFT_POSTS:]` card appears |

## Fix

Added `tabular` and `tabulate` to the TABLE alternation in `_ARTIFACT_KEYWORDS`.

## Tests

Added parametrised test for the exact prod phrase.