### PR TITLE
fix(dma): generate actual markdown table; fix agent name bleed in posts; accordion toggle

### DIFF
--- a/src/CP/FrontEnd/src/components/DigitalMarketingActivationWizard.tsx
+++ b/src/CP/FrontEnd/src/components/DigitalMarketingActivationWizard.tsx
@@ -441,7 +441,7 @@ export function DigitalMarketingActivationWizard({
   const [outputItemReceipts, setOutputItemReceipts] = useState<Record<string, string>>({})
   const [expandedOutputItems, setExpandedOutputItems] = useState<Record<string, boolean>>({})
   const chatScrollRef = useRef<HTMLDivElement | null>(null)
-  const [activeBriefSection, setActiveBriefSection] = useState<'brief' | 'objective' | 'status' | 'next' | 'controls' | 'output'>('brief')
+  const [activeBriefSection, setActiveBriefSection] = useState<'brief' | 'objective' | 'status' | 'next' | 'controls' | 'output' | null>('brief')
   const profileRef = useRef<ProfileData | null>(null)
 
   const hiredInstanceId = useMemo(
@@ -2744,7 +2744,7 @@ export function DigitalMarketingActivationWizard({
 
             <div className="dma-brief-accordion">
               <section className={`dma-brief-accordion-item${activeBriefSection === 'brief' ? ' is-open' : ''}`}>
-                <button type="button" className="dma-brief-accordion-trigger" onClick={() => setActiveBriefSection('brief')} aria-expanded={activeBriefSection === 'brief'}>
+                <button type="button" className="dma-brief-accordion-trigger" onClick={() => setActiveBriefSection(s => s === 'brief' ? null : 'brief')} aria-expanded={activeBriefSection === 'brief'}>
                   <div className="dma-brief-accordion-heading">
                     <span className="dma-wizard-section-label">Live business brief</span>
                     <span className="dma-brief-accordion-title">What the DMA understands so far</span>
@@ -2769,7 +2769,7 @@ export function DigitalMarketingActivationWizard({
               </section>
 
               <section className={`dma-brief-accordion-item${activeBriefSection === 'objective' ? ' is-open' : ''}`}>
-                <button type="button" className="dma-brief-accordion-trigger" onClick={() => setActiveBriefSection('objective')} aria-expanded={activeBriefSection === 'objective'}>
+                <button type="button" className="dma-brief-accordion-trigger" onClick={() => setActiveBriefSection(s => s === 'objective' ? null : 'objective')} aria-expanded={activeBriefSection === 'objective'}>
                   <div className="dma-brief-accordion-heading">
                     <span className="dma-wizard-section-label">Business objective</span>
                     <span className="dma-brief-accordion-title">What success should look like</span>
@@ -2789,7 +2789,7 @@ export function DigitalMarketingActivationWizard({
               </section>
 
               <section className={`dma-brief-accordion-item${activeBriefSection === 'status' ? ' is-open' : ''}`}>
-                <button type="button" className="dma-brief-accordion-trigger" onClick={() => setActiveBriefSection('status')} aria-expanded={activeBriefSection === 'status'}>
+                <button type="button" className="dma-brief-accordion-trigger" onClick={() => setActiveBriefSection(s => s === 'status' ? null : 'status')} aria-expanded={activeBriefSection === 'status'}>
                   <div className="dma-brief-accordion-heading">
                     <span className="dma-wizard-section-label">Operating status</span>
                     <span className="dma-brief-accordion-title">Readiness signals</span>
@@ -2811,7 +2811,7 @@ export function DigitalMarketingActivationWizard({
               </section>
 
               <section className={`dma-brief-accordion-item${activeBriefSection === 'next' ? ' is-open' : ''}`}>
-                <button type="button" className="dma-brief-accordion-trigger" onClick={() => setActiveBriefSection('next')} aria-expanded={activeBriefSection === 'next'}>
+                <button type="button" className="dma-brief-accordion-trigger" onClick={() => setActiveBriefSection(s => s === 'next' ? null : 'next')} aria-expanded={activeBriefSection === 'next'}>
                   <div className="dma-brief-accordion-heading">
                     <span className="dma-wizard-section-label">Next action</span>
                     <span className="dma-brief-accordion-title">What to answer or do next</span>
@@ -2834,7 +2834,7 @@ export function DigitalMarketingActivationWizard({
               </section>
 
               <section className={`dma-brief-accordion-item${activeBriefSection === 'controls' ? ' is-open' : ''}`}>
-                <button type="button" className="dma-brief-accordion-trigger" onClick={() => setActiveBriefSection('controls')} aria-expanded={activeBriefSection === 'controls'}>
+                <button type="button" className="dma-brief-accordion-trigger" onClick={() => setActiveBriefSection(s => s === 'controls' ? null : 'controls')} aria-expanded={activeBriefSection === 'controls'}>
                   <div className="dma-brief-accordion-heading">
                     <span className="dma-wizard-section-label">Setup controls</span>
                     <span className="dma-brief-accordion-title">Pin details and unlock activation</span>

--- a/src/Plant/BackEnd/api/v1/digital_marketing_activation.py
+++ b/src/Plant/BackEnd/api/v1/digital_marketing_activation.py
@@ -169,45 +169,91 @@ async def _build_auto_draft(
 ) -> dict[str, Any]:
     """Build and persist a draft batch inline from the chat handler. Returns the serialisable batch dict."""
     playbook = _dma_playbook()
-    brand_name = str(workspace.get("brand_name") or record.nickname or "").strip()
+    # Use the customer's brand name from the workspace brief — never fall back to the
+    # agent's own hire nickname (that causes the agent's personal name to appear in posts).
+    brand_name = str(workspace.get("brand_name") or "").strip()
     location = str(workspace.get("location") or "").strip()
     language = str(workspace.get("primary_language") or "en").strip()
 
-    subject = master_theme or brand_name or "the approved content plan"
-    requested_artifacts = [
-        ArtifactRequest(
-            artifact_type=art,
-            prompt=f"Create a {art.value.replace('_', ' ')} asset for: {subject}",
-            metadata={"source": "dma_chat_intent", "channel": "youtube"},
-        )
-        for art in artifact_types
-    ]
-
-    result = execute_marketing_multichannel_v1(
-        playbook,
-        SkillExecutionInput(
-            theme=master_theme or brand_name,
-            brand_name=brand_name,
-            offer=None,
-            location=location or None,
-            audience=None,
-            tone=None,
-            language=language,
-            channels=[ChannelName.YOUTUBE],
-            requested_artifacts=requested_artifacts,
-        ),
-    )
-
     batch_id = str(uuid4())
-    posts = [
-        DraftPostRecord(
-            post_id=str(uuid4()),
-            channel=v.channel,
-            text=v.text,
-            hashtags=v.hashtags,
+    posts: List[DraftPostRecord] = []
+
+    # ── TABLE artifact: build a GFM markdown table from campaign themes ──────
+    if ArtifactType.TABLE in artifact_types:
+        campaign_setup: dict[str, Any] = workspace.get("campaign_setup") or {}
+        derived_themes: List[dict[str, Any]] = campaign_setup.get("derived_themes") or []
+        master_theme_val = campaign_setup.get("master_theme") or master_theme or brand_name or "Content Plan"
+
+        if derived_themes:
+            header = f"**Master Theme:** {master_theme_val}\n\n"
+            table_lines = [
+                "| # | Theme | Description | Frequency |",
+                "|---|-------|-------------|-----------|",
+            ]
+            for i, theme in enumerate(derived_themes, 1):
+                title = str(theme.get("title") or "").replace("|", "\\|")
+                desc = str(theme.get("description") or "").replace("|", "\\|")
+                freq = str(theme.get("frequency") or "").replace("|", "\\|")
+                table_lines.append(f"| {i} | {title} | {desc} | {freq} |")
+            table_text = header + "\n".join(table_lines)
+        else:
+            table_text = (
+                f"**Master Theme:** {master_theme_val}\n\n"
+                "| # | Theme | Description | Frequency |\n"
+                "|---|-------|-------------|----------|\n"
+                f"| 1 | {master_theme_val} | Content plan for {brand_name or 'your brand'} | weekly |\n"
+            )
+
+        posts.append(
+            DraftPostRecord(
+                post_id=str(uuid4()),
+                channel="youtube",
+                text=table_text,
+                artifact_type="table",
+                hashtags=[],
+            )
         )
-        for v in result.output.variants
-    ]
+
+    # ── Non-table artifacts: run the deterministic channel adapters ───────────
+    non_table_types = [a for a in artifact_types if a != ArtifactType.TABLE]
+    if non_table_types or not posts:
+        subject = master_theme or brand_name or "the approved content plan"
+        requested_artifacts = [
+            ArtifactRequest(
+                artifact_type=art,
+                prompt=f"Create a {art.value.replace('_', ' ')} asset for: {subject}",
+                metadata={"source": "dma_chat_intent", "channel": "youtube"},
+            )
+            for art in (non_table_types or [ArtifactType.TABLE])
+        ]
+
+        channel_brand = brand_name or "Brand"
+        result = execute_marketing_multichannel_v1(
+            playbook,
+            SkillExecutionInput(
+                theme=master_theme or channel_brand,
+                brand_name=channel_brand,
+                offer=None,
+                location=location or None,
+                audience=None,
+                tone=None,
+                language=language,
+                channels=[ChannelName.YOUTUBE],
+                requested_artifacts=requested_artifacts,
+            ),
+        )
+
+        for v in result.output.variants:
+            art_type: str = non_table_types[0].value if non_table_types else "text"
+            posts.append(
+                DraftPostRecord(
+                    post_id=str(uuid4()),
+                    channel=v.channel,
+                    text=v.text,
+                    artifact_type=art_type,
+                    hashtags=v.hashtags,
+                )
+            )
 
     batch = DraftBatchRecord(
         batch_id=batch_id,
@@ -215,7 +261,7 @@ async def _build_auto_draft(
         hired_instance_id=record.hired_instance_id,
         campaign_id=campaign_id,
         customer_id=str(record.customer_id or "") if record.customer_id else None,
-        theme=result.output.canonical.theme,
+        theme=master_theme or brand_name,
         brand_name=brand_name,
         brief_summary=None,
         created_at=datetime.utcnow(),

--- a/src/Plant/BackEnd/tests/test_dma_chat_intent.py
+++ b/src/Plant/BackEnd/tests/test_dma_chat_intent.py
@@ -1,12 +1,16 @@
 """Unit tests for DMA chat intent detection (fix/dma-chat-intent-to-action).
 
-Tests cover _detect_generation_intent in digital_marketing_activation.py.
+Tests cover _detect_generation_intent and _build_auto_draft in
+digital_marketing_activation.py.
 """
 from __future__ import annotations
 
+import asyncio
+from unittest.mock import MagicMock
+
 import pytest
 
-from api.v1.digital_marketing_activation import _detect_generation_intent
+from api.v1.digital_marketing_activation import _build_auto_draft, _detect_generation_intent
 from agent_mold.skills.playbook import ArtifactType
 
 
@@ -139,3 +143,111 @@ def test_case_insensitive_verb() -> None:
 def test_case_insensitive_approval() -> None:
     should_gen, arts = _detect_generation_intent("YES", "approval_ready")
     assert should_gen is True
+
+
+# ---------------------------------------------------------------------------
+# _build_auto_draft — TABLE path regression tests
+# ---------------------------------------------------------------------------
+
+def _make_record(nickname: str = "Yogesh Khandge") -> MagicMock:
+    r = MagicMock()
+    r.nickname = nickname
+    r.agent_id = "AGT-TEST-1"
+    r.hired_instance_id = "HAI-TEST-1"
+    r.customer_id = "CUST-TEST-1"
+    return r
+
+
+def test_build_auto_draft_table_produces_gfm_table() -> None:
+    """TABLE artifact type must produce a GFM markdown table from derived_themes."""
+    workspace = {
+        "brand_name": "Beauty Artist",
+        "location": "Pune",
+        "campaign_setup": {
+            "master_theme": "Natural Bridal Looks",
+            "derived_themes": [
+                {"title": "Bridal Prep", "description": "Tutorials for the big day", "frequency": "weekly"},
+                {"title": "Affordable Glam", "description": "Budget beauty tips", "frequency": "bi-weekly"},
+            ],
+        },
+    }
+    result = asyncio.run(
+        _build_auto_draft(
+            record=_make_record(),
+            workspace=workspace,
+            master_theme="Natural Bridal Looks",
+            campaign_id=None,
+            artifact_types=[ArtifactType.TABLE],
+            db=None,
+        )
+    )
+
+    posts = result["posts"]
+    assert len(posts) == 1
+    p = posts[0]
+    assert p["artifact_type"] == "table"
+    # A GFM table must contain pipe characters
+    assert "|" in p["text"]
+    # Derived themes must be present
+    assert "Bridal Prep" in p["text"]
+    assert "Affordable Glam" in p["text"]
+
+
+def test_build_auto_draft_table_no_agent_name_bleed() -> None:
+    """Agent hire nickname must NEVER appear in generated table content or hashtags."""
+    workspace = {
+        "brand_name": "Sunrise Cafe",
+        "campaign_setup": {
+            "master_theme": "Coffee Culture",
+            "derived_themes": [
+                {"title": "Morning Rituals", "description": "Wake-up brews", "frequency": "daily"},
+            ],
+        },
+    }
+    result = asyncio.run(
+        _build_auto_draft(
+            record=_make_record(nickname="Yogesh Khandge"),
+            workspace=workspace,
+            master_theme="Coffee Culture",
+            campaign_id=None,
+            artifact_types=[ArtifactType.TABLE],
+            db=None,
+        )
+    )
+
+    posts = result["posts"]
+    assert posts, "Expected at least one post"
+    p = posts[0]
+    assert "Yogesh" not in p["text"], "Agent first name must not appear in post text"
+    assert "Khandge" not in p["text"], "Agent last name must not appear in post text"
+    hashtags = p.get("hashtags") or []
+    for tag in hashtags:
+        assert "Yogesh" not in tag and "Khandge" not in tag, (
+            f"Agent name found in hashtag: {tag}"
+        )
+
+
+def test_build_auto_draft_table_empty_themes_fallback() -> None:
+    """When derived_themes is empty, a fallback single-row table is still produced."""
+    workspace = {
+        "brand_name": "TechStartup",
+        "campaign_setup": {
+            "master_theme": "Product Launch",
+            "derived_themes": [],
+        },
+    }
+    result = asyncio.run(
+        _build_auto_draft(
+            record=_make_record(),
+            workspace=workspace,
+            master_theme="Product Launch",
+            campaign_id=None,
+            artifact_types=[ArtifactType.TABLE],
+            db=None,
+        )
+    )
+
+    posts = result["posts"]
+    assert len(posts) == 1
+    assert posts[0]["artifact_type"] == "table"
+    assert "|" in posts[0]["text"]


### PR DESCRIPTION
## What

Three bugs reported after deploying PR #1040 are fixed here.

## Root causes & fixes

| Root cause | Impact | Fix |
|---|---|---|
| `_build_auto_draft` only called channel adapters; no TABLE path existed | "Review the table below" message from DMA with no actual table ever appearing | Added explicit TABLE branch that reads `workspace.campaign_setup.derived_themes` and builds a GFM markdown table (`# | Theme | Description | Frequency`) |
| `brand_name = workspace.get("brand_name") or record.nickname` | Agent's own hire name ("Yogesh Khandge") leaked into post content and hashtags (`#Yogeshkhandge`) | Removed `record.nickname` fallback; safe fallback is `"Brand"` |
| Accordion state type excluded `null`; click on open section was a no-op | Right-panel accordion sections could not be closed once opened | State type widened to `...\| null`; all 5 static setters replaced with toggle pattern |

## Tests

- 3 new regression tests in `test_dma_chat_intent.py`:
  - `test_build_auto_draft_table_produces_gfm_table` — GFM pipe table is generated
  - `test_build_auto_draft_table_no_agent_name_bleed` — agent nickname never in output
  - `test_build_auto_draft_table_empty_themes_fallback` — fallback row when no themes
- All 42 tests in file pass (39 pre-existing + 3 new)