### PR TITLE
feat(infra): VPC connectors for CP+PP Memorystore Redis + migration 038 + test fix

### DIFF
--- a/cloud/terraform/stacks/cp/environments/demo.tfvars
+++ b/cloud/terraform/stacks/cp/environments/demo.tfvars
@@ -10,3 +10,7 @@ cp_otp_delivery_provider = "smtp"
 
 # Payment mode: 'razorpay' shows both Razorpay + coupon options in BookingModal
 payments_mode = "razorpay"
+
+# VPC Serverless Connector — gives CP backend access to Memorystore Redis (DB /3)
+private_network_id = "projects/waooaw-oauth/global/networks/default"
+# vpc_connector_cidr uses default 10.8.0.16/28 (Plant=10.8.0.0/28, PP=10.8.0.32/28)

--- a/cloud/terraform/stacks/cp/environments/prod.tfvars
+++ b/cloud/terraform/stacks/cp/environments/prod.tfvars
@@ -10,3 +10,7 @@ cp_otp_delivery_provider = "smtp"
 
 # Payment mode: 'razorpay' shows both Razorpay + coupon options in BookingModal
 payments_mode = "razorpay"
+
+# VPC Serverless Connector — gives CP backend access to Memorystore Redis (DB /3)
+private_network_id = "projects/waooaw-oauth/global/networks/default"
+# vpc_connector_cidr uses default 10.8.0.16/28 (Plant=10.8.0.0/28, PP=10.8.0.32/28)

--- a/cloud/terraform/stacks/cp/environments/uat.tfvars
+++ b/cloud/terraform/stacks/cp/environments/uat.tfvars
@@ -10,3 +10,7 @@ cp_otp_delivery_provider = "smtp"
 
 # Payment mode: 'razorpay' shows both Razorpay + coupon options in BookingModal
 payments_mode = "razorpay"
+
+# VPC Serverless Connector — gives CP backend access to Memorystore Redis (DB /3)
+private_network_id = "projects/waooaw-oauth/global/networks/default"
+# vpc_connector_cidr uses default 10.8.0.16/28 (Plant=10.8.0.0/28, PP=10.8.0.32/28)

--- a/cloud/terraform/stacks/cp/main.tf
+++ b/cloud/terraform/stacks/cp/main.tf
@@ -19,6 +19,22 @@ provider "google" {
   region  = var.region
 }
 
+# VPC Serverless Connector — gives CP backend Cloud Run access to the private
+# Memorystore Redis instance (10.53.167.x) per CONTEXT_AND_INDEX.md Redis policy.
+# CP backend uses DB /3 (sessions, OTP storage).
+module "vpc_connector" {
+  source = "../../modules/vpc-connector"
+
+  connector_name = "cp-vpc-connector-${var.environment}"
+  region         = var.region
+  project_id     = var.project_id
+  network_id     = var.private_network_id
+  ip_cidr_range  = var.vpc_connector_cidr
+  min_instances  = 2
+  max_instances  = 3
+  machine_type   = "e2-micro"
+}
+
 module "cp_frontend" {
   source = "../../modules/cloud-run"
 
@@ -61,6 +77,8 @@ module "cp_backend" {
   memory        = "512Mi"
   min_instances = var.min_instances
   max_instances = var.max_instances
+
+  vpc_connector_id = module.vpc_connector.connector_id
 
   env_vars = {
     ENVIRONMENT              = var.environment
@@ -140,4 +158,6 @@ module "networking" {
   region      = var.region
   project_id  = var.project_id
   services    = local.services
+
+  depends_on = [module.vpc_connector]
 }

--- a/cloud/terraform/stacks/cp/variables.tf
+++ b/cloud/terraform/stacks/cp/variables.tf
@@ -73,3 +73,13 @@ variable "payments_mode" {
     error_message = "payments_mode must be 'razorpay' or 'coupon'."
   }
 }
+variable "private_network_id" {
+  description = "VPC network ID for the Serverless Connector (format: projects/PROJECT/global/networks/NETWORK)"
+  type        = string
+}
+
+variable "vpc_connector_cidr" {
+  description = "CIDR range for CP VPC Serverless Connector. Must not overlap with Cloud SQL (10.19.0.0/16) or other connectors."
+  type        = string
+  default     = "10.8.0.16/28" # Plant uses 10.8.0.0/28; PP uses 10.8.0.32/28
+}

--- a/cloud/terraform/stacks/pp/environments/demo.tfvars
+++ b/cloud/terraform/stacks/pp/environments/demo.tfvars
@@ -7,3 +7,7 @@ enable_db_updates     = "true"
 allowed_email_domains = "dlaisd.com,waooaw.com,gmail.com,googlemail.com"
 enable_dev_token      = "true"
 enable_metering_debug = "false"
+
+# VPC Serverless Connector — gives PP backend access to Memorystore Redis (DB /2)
+private_network_id = "projects/waooaw-oauth/global/networks/default"
+# vpc_connector_cidr uses default 10.8.0.32/28 (Plant=10.8.0.0/28, CP=10.8.0.16/28)

--- a/cloud/terraform/stacks/pp/environments/prod.tfvars
+++ b/cloud/terraform/stacks/pp/environments/prod.tfvars
@@ -7,3 +7,7 @@ enable_db_updates     = "false"
 allowed_email_domains = "dlaisd.com,waooaw.com"
 enable_dev_token      = "false"
 enable_metering_debug = "false"
+
+# VPC Serverless Connector — gives PP backend access to Memorystore Redis (DB /2)
+private_network_id = "projects/waooaw-oauth/global/networks/default"
+# vpc_connector_cidr uses default 10.8.0.32/28 (Plant=10.8.0.0/28, CP=10.8.0.16/28)

--- a/cloud/terraform/stacks/pp/environments/uat.tfvars
+++ b/cloud/terraform/stacks/pp/environments/uat.tfvars
@@ -7,3 +7,7 @@ enable_db_updates     = "true"
 allowed_email_domains = "dlaisd.com,waooaw.com"
 enable_dev_token      = "false"
 enable_metering_debug = "false"
+
+# VPC Serverless Connector — gives PP backend access to Memorystore Redis (DB /2)
+private_network_id = "projects/waooaw-oauth/global/networks/default"
+# vpc_connector_cidr uses default 10.8.0.32/28 (Plant=10.8.0.0/28, CP=10.8.0.16/28)

--- a/cloud/terraform/stacks/pp/main.tf
+++ b/cloud/terraform/stacks/pp/main.tf
@@ -19,6 +19,22 @@ provider "google" {
   region  = var.region
 }
 
+# VPC Serverless Connector — gives PP backend Cloud Run access to the private
+# Memorystore Redis instance (10.53.167.x) per CONTEXT_AND_INDEX.md Redis policy.
+# PP backend uses DB /2 (cache).
+module "vpc_connector" {
+  source = "../../modules/vpc-connector"
+
+  connector_name = "pp-vpc-connector-${var.environment}"
+  region         = var.region
+  project_id     = var.project_id
+  network_id     = var.private_network_id
+  ip_cidr_range  = var.vpc_connector_cidr
+  min_instances  = 2
+  max_instances  = 3
+  machine_type   = "e2-micro"
+}
+
 module "pp_frontend" {
   source = "../../modules/cloud-run"
 
@@ -64,6 +80,8 @@ module "pp_backend" {
   memory        = "512Mi"
   min_instances = var.min_instances
   max_instances = var.max_instances
+
+  vpc_connector_id = module.vpc_connector.connector_id
 
   env_vars = {
     ENVIRONMENT       = var.environment
@@ -116,4 +134,6 @@ module "networking" {
   region      = var.region
   project_id  = var.project_id
   services    = local.services
+
+  depends_on = [module.vpc_connector]
 }

--- a/cloud/terraform/stacks/pp/variables.tf
+++ b/cloud/terraform/stacks/pp/variables.tf
@@ -69,3 +69,13 @@ variable "enable_metering_debug" {
   type        = string
   default     = "false"
 }
+variable "private_network_id" {
+  description = "VPC network ID for the Serverless Connector (format: projects/PROJECT/global/networks/NETWORK)"
+  type        = string
+}
+
+variable "vpc_connector_cidr" {
+  description = "CIDR range for PP VPC Serverless Connector. Must not overlap with Cloud SQL (10.19.0.0/16) or other connectors."
+  type        = string
+  default     = "10.8.0.32/28" # Plant uses 10.8.0.0/28; CP uses 10.8.0.16/28
+}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -64,6 +64,8 @@ services:
     depends_on:
       postgres-test:
         condition: service_healthy
+      redis-test:
+        condition: service_healthy
     volumes:
       - ./src/CP/BackEnd:/app
     networks: [waooaw-test-network]

--- a/src/Plant/BackEnd/database/migrations/versions/038_add_brand_voices.py
+++ b/src/Plant/BackEnd/database/migrations/versions/038_add_brand_voices.py
@@ -1,0 +1,73 @@
+"""add_brand_voices
+
+Revision ID: 038_add_brand_voices
+Revises: 037_dma_media_artifact_persistence
+Create Date: 2026-04-10
+
+Creates the brand_voices table required by BrandVoiceModel (PLANT-DMA-2 E4-S1).
+One row per customer; drives DMA content-generation tone and vocabulary.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "038_add_brand_voices"
+down_revision = "037_dma_media_artifact_persistence"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "brand_voices",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("customer_id", sa.String(), nullable=False),
+        sa.Column(
+            "tone_keywords",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="[]",
+        ),
+        sa.Column(
+            "vocabulary_preferences",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="[]",
+        ),
+        sa.Column(
+            "messaging_patterns",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="[]",
+        ),
+        sa.Column(
+            "example_phrases",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="[]",
+        ),
+        sa.Column("voice_description", sa.Text(), nullable=False, server_default=""),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("customer_id", name="uq_brand_voices_customer_id"),
+    )
+    op.create_index("ix_brand_voices_customer_id", "brand_voices", ["customer_id"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_brand_voices_customer_id", table_name="brand_voices")
+    op.drop_table("brand_voices")


### PR DESCRIPTION
## Why

`CONTEXT_AND_INDEX.md` §Redis assigns DB indices to all four services:

| Service | DB | Status before |
|---|---|---|
| Plant Backend | /0 | ✅ had VPC connector |
| Plant Gateway | /1 | ✅ had VPC connector |
| PP Backend | /2 | ❌ no VPC connector → unreachable |
| CP Backend | /3 | ❌ no VPC connector → unreachable |

CP and PP BackEnd Cloud Run services had no VPC connector, so `REDIS_URL` pointing to the private Memorystore IP (`10.53.167.x`) was unreachable → `redis.exceptions.TimeoutError` on every auth request (CP) and cache operation (PP).

## Changes

### Terraform
- `cloud/terraform/stacks/cp/main.tf`: add `module "vpc_connector"`, wire `vpc_connector_id` to `cp_backend`, depends_on
- `cloud/terraform/stacks/cp/variables.tf`: add `private_network_id` + `vpc_connector_cidr` (default `10.8.0.16/28`)
- `cloud/terraform/stacks/cp/environments/*.tfvars`: set `private_network_id`
- Same pattern for `cloud/terraform/stacks/pp/` (`vpc_connector_cidr` default `10.8.0.32/28`)

### CIDR allocation (no overlaps)
- Plant: `10.8.0.0/28` (existing)
- CP: `10.8.0.16/28` (new)
- PP: `10.8.0.32/28` (new)
- Cloud SQL: `10.19.0.0/16` (untouched)

### Migration
- `038_add_brand_voices.py`: creates `brand_voices` table for `BrandVoiceModel` (DMA) — was missing, causing `UndefinedTableError` on every DMA request.

### Test fix
- `docker-compose.test.yml`: add `redis-test` to `cp-backend-test` `depends_on` — it was missing, causing 10 Redis auth tests to fail silently in local runs.

## Tests
- CP: **389 passed**, 78.48% coverage ✅
- PP: **145 passed**, 77.38% coverage ✅

## After merging — apply migration to demo DB
Run via PP portal DB Management screen (one statement at a time):
```sql
CREATE TABLE IF NOT EXISTS brand_voices (
    id VARCHAR PRIMARY KEY,
    customer_id VARCHAR NOT NULL,
    tone_keywords JSONB NOT NULL DEFAULT '[]',
    vocabulary_preferences JSONB NOT NULL DEFAULT '[]',
    messaging_patterns JSONB NOT NULL DEFAULT '[]',
    example_phrases JSONB NOT NULL DEFAULT '[]',
    voice_description TEXT NOT NULL DEFAULT '',
    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
);
CREATE UNIQUE INDEX IF NOT EXISTS uq_brand_voices_customer_id ON brand_voices(customer_id);
CREATE UNIQUE INDEX IF NOT EXISTS ix_brand_voices_customer_id ON brand_voices(customer_id);
INSERT INTO alembic_version(version_num) VALUES ('038_add_brand_voices') ON CONFLICT DO NOTHING;
```