### PR TITLE
fix(plant-gateway): remove baked service URL env vars from Dockerfile

### DIFF
--- a/src/Plant/Gateway/Dockerfile
+++ b/src/Plant/Gateway/Dockerfile
@@ -35,12 +35,6 @@ ENV PATH=/home/gateway/.local/bin:$PATH
 # Ensure application root is importable for test runners that don't add cwd.
 ENV PYTHONPATH=/app
 
-# Environment variables (override at runtime)
-ENV PLANT_BACKEND_URL=http://plant-backend:8001
-ENV REDIS_URL=redis://redis:6379
-ENV OPA_URL=http://opa:8181
-ENV ENVIRONMENT=production
-
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
     CMD python -c "import httpx; httpx.get('http://localhost:8000/health')"


### PR DESCRIPTION
## Summary

Removes four baked `ENV` runtime-config lines from `src/Plant/Gateway/Dockerfile` that violated the image promotion rule.

### Root cause

The Dockerfile contained hardcoded docker-compose hostnames as `ENV` defaults:

```dockerfile
ENV PLANT_BACKEND_URL=http://plant-backend:8001
ENV REDIS_URL=redis://redis:6379
ENV OPA_URL=http://opa:8181
ENV ENVIRONMENT=production
```

These are only valid inside a docker-compose network. In Cloud Run, `redis://redis:6379` and `http://plant-backend:8001` do not resolve. Cloud Run overrides them at deploy time via Terraform `env_vars`/`secrets` blocks, but baking them in creates a silent fallback risk if that injection ever fails.

### Fix

Removed all four lines. Only `PYTHONPATH` and `PATH` remain — these are build-time tooling vars, not environment-specific runtime config.

### Why safe

`cloud/terraform/stacks/plant/main.tf` already injects `PLANT_BACKEND_URL`, `REDIS_URL`, `OPA_URL`, and `ENVIRONMENT` at every deploy for all three environments (demo/uat/prod). No fallback needed.

### Other Dockerfiles

| Dockerfile | Status |
|---|---|
| CP BackEnd | ✅ Already clean |
| PP BackEnd | ✅ Already clean |
| Plant BackEnd | ✅ Already clean |
| Plant Gateway | ✅ Fixed in this PR |