### PR TITLE
fix(DMA-CONV): DMA produces tables when asked instead of conversational filler

### DIFF
--- a/src/Plant/BackEnd/api/v1/digital_marketing_activation.py
+++ b/src/Plant/BackEnd/api/v1/digital_marketing_activation.py
@@ -40,6 +40,32 @@ logger.addFilter(PiiMaskingFilter())
 _WORKSPACE_KEY = "digital_marketing_activation"
 _DIGITAL_MARKETING_AGENT_TYPE = "marketing.digital_marketing.v1"
 
+# Bare-minimum fields required before the DMA can generate a rough theme draft.
+# The full 11 fields are needed for approval_ready, but these 5 unlock early drafts.
+CORE_REQUIRED_FIELDS: list[str] = [
+    "industry",
+    "locality",
+    "target_audience",
+    "objective",
+    "offer",
+]
+
+# Human-readable purpose for each field — sent to the LLM so it can explain
+# *why* each piece of information matters (not just demand it).
+_FIELD_PURPOSE: dict[str, str] = {
+    "business_background": "So your content reflects what you actually do, not generic marketing.",
+    "objective": "So every theme drives a specific result — leads, bookings, trust — not random content.",
+    "industry": "So the strategy uses the right language, trends, and competitor context for your field.",
+    "locality": "So the content targets your actual catchment area and local search terms.",
+    "target_audience": "So every post speaks to the right customer segment, not everyone.",
+    "persona": "So the content tone and examples match your ideal customer's life-stage and motivation.",
+    "tone": "So the brand voice feels consistent and intentional across all content.",
+    "offer": "So each post has a clear call-to-action tied to something you actually sell.",
+    "channel_intent": "So the content format and style match the platform you chose (e.g. YouTube vs Instagram).",
+    "posting_cadence": "So the theme calendar has the right number of slots and pacing.",
+    "success_metrics": "So we can measure whether the content is working and adjust.",
+}
+
 # Canonical mapping from THEME_DISCOVERY_REQUIRED_FIELDS to workshop summary keys.
 # Defined once at module level to avoid drift between prompt construction and validation.
 _FIELD_TO_SUMMARY_KEY: dict[str, str] = {
@@ -167,7 +193,7 @@ def _detect_generation_intent(
         return True, requested_artifact_types
 
     # Pure approval signal when strategy is ready — generate table by default
-    if has_approval_signal and workshop_status in {"approval_ready", "approved"}:
+    if has_approval_signal and workshop_status in {"approval_ready", "approved", "draft_ready"}:
         # Default to table if no specific artifact mentioned
         return True, requested_artifact_types or [ArtifactType.TABLE]
 
@@ -644,6 +670,11 @@ def _theme_workshop_prompt(
                     "missing": len(missing_fields),
                     "locked_fields": locked_fields,
                     "missing_fields": missing_fields,
+                    "core_fields": CORE_REQUIRED_FIELDS,
+                    "core_filled": [f for f in CORE_REQUIRED_FIELDS if f in locked_fields],
+                    "core_missing": [f for f in CORE_REQUIRED_FIELDS if f not in locked_fields],
+                    "can_generate_draft": len([f for f in CORE_REQUIRED_FIELDS if f in locked_fields]) >= 5,
+                    "field_purposes": {f: _FIELD_PURPOSE.get(f, "") for f in missing_fields},
                 },
             },
             "pending_customer_input": pending_input,
@@ -845,14 +876,42 @@ def _parse_theme_workshop_response(
         },
     }
     
+    # Count how many CORE fields are filled (for draft-readiness)
+    core_filled_count = sum(
+        1 for req_field in CORE_REQUIRED_FIELDS
+        if str(workshop["summary"].get(_FIELD_TO_SUMMARY_KEY.get(req_field, req_field)) or "").strip()
+    )
+    workshop["brief_progress"]["core_filled_count"] = core_filled_count
+    workshop["brief_progress"]["can_generate_draft"] = core_filled_count >= len(CORE_REQUIRED_FIELDS)
+
     if workshop["status"] == "approval_ready" and filled_count < 9:
-        logger.warning(
-            "LLM tried approval_ready with only %d/%d fields filled — forcing discovery",
-            filled_count, len(THEME_DISCOVERY_REQUIRED_FIELDS),
-        )
-        workshop["status"] = "discovery"
-        if not workshop["current_focus_question"]:
-            workshop["current_focus_question"] = "A few details are still needed before I can lock the strategy. What is the primary business result this content should drive?"
+        # If all 5 core fields are filled, allow "draft_ready" — a middle state
+        # where the DMA can produce a rough theme calendar but not final approval.
+        if core_filled_count >= len(CORE_REQUIRED_FIELDS):
+            logger.info(
+                "LLM tried approval_ready with %d/%d fields (%d/%d core) — allowing draft_ready",
+                filled_count, len(THEME_DISCOVERY_REQUIRED_FIELDS),
+                core_filled_count, len(CORE_REQUIRED_FIELDS),
+            )
+            workshop["status"] = "draft_ready"
+        else:
+            core_missing = [
+                f for f in CORE_REQUIRED_FIELDS
+                if not str(workshop["summary"].get(_FIELD_TO_SUMMARY_KEY.get(f, f)) or "").strip()
+            ]
+            logger.warning(
+                "LLM tried approval_ready with only %d/%d fields filled (core missing: %s) — forcing discovery",
+                filled_count, len(THEME_DISCOVERY_REQUIRED_FIELDS), core_missing,
+            )
+            workshop["status"] = "discovery"
+            missing_explanations = "; ".join(
+                f"{f}: {_FIELD_PURPOSE.get(f, '')}" for f in core_missing[:3]
+            )
+            if not workshop["current_focus_question"]:
+                workshop["current_focus_question"] = (
+                    f"To build your content calendar I still need: {', '.join(core_missing)}. "
+                    f"{missing_explanations}. Which of these can you share first?"
+                )
     
     return master_theme or "Digital marketing activation plan", derived_themes, workshop
 
@@ -1231,8 +1290,29 @@ async def generate_theme_plan(
                 "\n\nPERFORMANCE INSIGHTS:\n"
                 "Performance insights from previous content cycles are provided below. Use these to guide theme recommendations — favor topics and formats that drove higher engagement. "
                 "Reference specific performance data when making suggestions. "
-                "\n\nDELIVERABLE REQUEST RULE:\n"
-                "When the customer asks for any concrete deliverable (plan, table, draft, schedule), produce it immediately. Do not deflect with more questions. "
+                "\n\nDELIVERABLE REQUEST RULE (MANDATORY — READ CAREFULLY):\n"
+                "When the customer asks for a concrete deliverable (plan, table, draft, schedule, themes, calendar):\n"
+                "1. Check the required_fields_checklist in the context below.\n"
+                "2. If 5 or more CORE fields are filled (industry, locality, target_audience, objective, offer), "
+                "produce the deliverable NOW — return master_theme and 2-4 derived_themes in the JSON response. "
+                "Use reasonable defaults for any still-missing non-core fields and note what you assumed.\n"
+                "3. If fewer than 5 core fields are filled, tell the customer clearly: "
+                "'To build your content calendar I need [list the missing core fields]. Here is why each matters: [one line per field from the field_purposes below].' "
+                "Then ask for the most important missing field. Do NOT produce empty themes or filler text.\n"
+                "4. NEVER respond with just conversational text like 'I would be happy to provide...' when a deliverable is requested. "
+                "Either produce the deliverable or state exactly what is missing.\n"
+                "\n\nFIELD PURPOSE REFERENCE (use when explaining why a field is needed):\n"
+                "- industry: So the strategy uses the right language, trends, and competitor context.\n"
+                "- locality: So content targets your actual catchment area and local search terms.\n"
+                "- target_audience: So every post speaks to the right customer, not everyone.\n"
+                "- objective: So every theme drives a specific result, not random content.\n"
+                "- offer: So each post has a clear call-to-action tied to what you sell.\n"
+                "- persona: So content matches your ideal customer's life-stage and motivation.\n"
+                "- tone: So brand voice is consistent across all content.\n"
+                "- channel_intent: So content format matches the chosen platform.\n"
+                "- posting_cadence: So the calendar has the right pacing.\n"
+                "- success_metrics: So we can measure and adjust.\n"
+                "- business_background: So content reflects what you actually do.\n"
                 "\n\nAsk probing questions only until the strategy is strong enough for approval, then return a clear master theme, 2-4 derived themes, and a structured summary. "
                 "Always return JSON matching the requested response contract."
             ),
@@ -1287,7 +1367,68 @@ async def generate_theme_plan(
         pending_input,
         workshop_status=strategy_workshop.get("status", "discovery"),
     )
-    if should_generate and master_theme:
+    # Also allow generation when workshop is draft_ready (5+ core fields)
+    if not should_generate and strategy_workshop.get("status") == "draft_ready":
+        # Check if the pending input mentions a deliverable
+        should_generate, artifact_types = _detect_generation_intent(
+            pending_input,
+            workshop_status="approval_ready",  # Treat draft_ready like approval_ready for intent
+        )
+
+    # If we should generate a TABLE but derived_themes are empty, generate them now
+    if should_generate and ArtifactType.TABLE in artifact_types and not derived_themes:
+        brief = strategy_workshop.get("brief_progress", {})
+        core_filled = brief.get("core_filled_count", 0)
+        if core_filled >= len(CORE_REQUIRED_FIELDS):
+            # Second targeted LLM call: "generate themes from what we have"
+            try:
+                summary_snapshot = strategy_workshop.get("summary", {})
+                theme_gen_prompt = (
+                    f"Generate a content theme calendar for this business. Return ONLY JSON with "
+                    f"master_theme (string) and derived_themes (array of 2-4 objects with title, description, frequency, pillar).\n\n"
+                    f"Business: {summary_snapshot.get('profession_name', '')} in {summary_snapshot.get('location_focus', '')}\n"
+                    f"Audience: {summary_snapshot.get('audience', '')}\n"
+                    f"Goal: {summary_snapshot.get('business_goal', '')}\n"
+                    f"Offer: {summary_snapshot.get('cta', '')}\n"
+                    f"Tone: {summary_snapshot.get('tone', 'professional')}\n"
+                    f"Channel: {summary_snapshot.get('youtube_angle', 'YouTube')}\n"
+                    f"Brand: {workspace.get('brand_name', '')}"
+                )
+                theme_json_str = grok_complete(
+                    client,
+                    system="You are a content strategist. Return ONLY valid JSON with master_theme and derived_themes. No conversational text.",
+                    user=theme_gen_prompt,
+                    model="grok-3-latest",
+                    temperature=0.5,
+                )
+                import json as _json
+                theme_data = _json.loads(theme_json_str)
+                derived_themes = _normalize_derived_themes(theme_data.get("derived_themes", []))
+                if derived_themes:
+                    master_theme = str(theme_data.get("master_theme") or master_theme)
+                    # Persist the newly generated themes
+                    campaign_id = await _persist_theme_plan_to_campaign(
+                        record=record, workspace=workspace,
+                        master_theme=master_theme, derived_themes=derived_themes,
+                        campaign_setup=campaign_setup, db=db,
+                    )
+                    persisted_workspace = _build_theme_plan_workspace(
+                        workspace=workspace,
+                        campaign_setup={**campaign_setup, "strategy_workshop": strategy_workshop,
+                                        "master_theme": master_theme, "derived_themes": derived_themes},
+                        campaign_id=campaign_id,
+                        master_theme=master_theme,
+                        derived_themes=derived_themes,
+                    )
+                    if db is not None:
+                        await db.commit()
+                    logger.info("Generated themes via targeted LLM call for table intent, %d themes", len(derived_themes))
+            except Exception as exc:
+                logger.warning("Targeted theme generation for table intent failed: %s", exc)
+
+    # Only auto-generate when the workshop has enough field coverage
+    ws_status = strategy_workshop.get("status", "discovery")
+    if should_generate and master_theme and ws_status in ("draft_ready", "approval_ready", "approved"):
         try:
             auto_draft = await _build_auto_draft(
                 record=record,

--- a/src/Plant/BackEnd/tests/unit/test_digital_marketing_theme_generation_api.py
+++ b/src/Plant/BackEnd/tests/unit/test_digital_marketing_theme_generation_api.py
@@ -241,12 +241,14 @@ def test_generate_theme_plan_trims_incomplete_assistant_message(test_client, mon
     assert workshop["assistant_message"] == "I have refined the first month around peak wedding-planning demand."
     assert workshop["checkpoint_summary"] == "The content lane is now aligned to the strongest demand pockets."
     # The mock returns "approval_ready" but only 1/11 fields are filled (business_goal).
-    # The E1-S2 validation gate forces status back to "discovery" and injects a fallback question.
+    # The E1-S2 validation gate forces status back to "discovery" and injects a fallback question
+    # listing the missing core fields (industry, locality, target_audience, offer).
     assert workshop["status"] == "discovery"
-    assert workshop["current_focus_question"] == (
-        "A few details are still needed before I can lock the strategy. "
-        "What is the primary business result this content should drive?"
-    )
+    focus_q = workshop["current_focus_question"]
+    assert focus_q, "Expected a focus question about missing fields"
+    # The question should mention at least one missing core field
+    assert any(field in focus_q for field in ("industry", "locality", "target_audience", "offer")), \
+        f"Focus question should mention missing core fields, got: {focus_q}"
 
 
 @pytest.mark.unit

--- a/src/Plant/BackEnd/tests/unit/test_dma_prompt_fields.py
+++ b/src/Plant/BackEnd/tests/unit/test_dma_prompt_fields.py
@@ -108,8 +108,9 @@ class TestE1S1PromptRewrite:
         import inspect
         
         source = inspect.getsource(generate_theme_plan)
-        # The system prompt must contain the exact O6 enforcement phrase
-        assert "produce it immediately" in source.lower()
+        # The system prompt must contain the gated deliverable rule (replaced the old "produce it immediately")
+        assert "deliverable request rule" in source.lower()
+        assert "produce the deliverable now" in source.lower()
 
 
 class TestE1S2FieldCompletenessValidation:

--- a/src/Plant/BackEnd/tests/unit/test_dma_table_generation.py
+++ b/src/Plant/BackEnd/tests/unit/test_dma_table_generation.py
@@ -1,0 +1,503 @@
+"""Tests for DMA table generation — verifies that the conversation-to-table
+pipeline actually produces tables instead of conversational filler text.
+
+These tests cover the exact failure mode: user asks "give me a table" and
+the system returns only conversational text with no actual table/themes.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import api.v1.campaigns as campaigns_module
+
+
+def _create_marketing_hire(test_client, customer_id: str = "cust-dma-table") -> str:
+    checkout = test_client.post(
+        "/api/v1/payments/coupon/checkout",
+        json={
+            "coupon_code": "WAOOAW100",
+            "agent_id": "AGT-MKT-HEALTH-001",
+            "duration": "monthly",
+            "customer_id": customer_id,
+        },
+    )
+    assert checkout.status_code == 200
+    subscription_id = checkout.json()["subscription_id"]
+
+    draft = test_client.put(
+        "/api/v1/hired-agents/draft",
+        json={
+            "subscription_id": subscription_id,
+            "agent_id": "AGT-MKT-HEALTH-001",
+            "agent_type_id": "marketing.digital_marketing.v1",
+            "customer_id": customer_id,
+            "nickname": "Growth Copilot",
+            "theme": "dark",
+            "config": {
+                "primary_language": "en",
+                "timezone": "Asia/Kolkata",
+                "brand_name": "Acme Health",
+                "location": "Pune",
+                "offerings_services": ["Dental care"],
+                "platforms_enabled": ["youtube", "instagram"],
+            },
+        },
+    )
+    assert draft.status_code == 200
+    hired_instance_id = draft.json()["hired_instance_id"]
+
+    # Persist the workspace via the activation endpoint so brand_name is available
+    saved = test_client.put(
+        f"/api/v1/hired-agents/{hired_instance_id}/digital-marketing-activation",
+        json={
+            "customer_id": customer_id,
+            "workspace": {
+                "brand_name": "Acme Health",
+                "location": "Pune",
+                "primary_language": "en",
+                "timezone": "Asia/Kolkata",
+                "offerings_services": ["Dental care"],
+                "platforms_enabled": ["youtube"],
+            },
+        },
+    )
+    assert saved.status_code == 200
+
+    return hired_instance_id
+
+
+def _full_summary():
+    """All 11 fields filled — approval_ready should be allowed."""
+    return {
+        "profession_name": "Beauty Artist",
+        "location_focus": "Viman Nagar, Pune",
+        "customer_profile": "Brides aged 22-35 planning weddings",
+        "service_focus": "Bridal makeup and styling",
+        "signature_differentiator": "Personalized bridal look consultation",
+        "business_goal": "Drive repeat bookings and local reputation",
+        "first_content_direction": "Weekly bridal transformation tutorials",
+        "business_focus": "Bridal makeup studio in Viman Nagar",
+        "audience": "Brides and families in Viman Nagar area",
+        "positioning": "The go-to bridal artist in Viman Nagar",
+        "tone": "Warm, aspirational, confident",
+        "content_pillars": ["Tutorials", "Transformations", "Testimonials"],
+        "youtube_angle": "Bridal beauty tips and behind-the-scenes",
+        "cta": "Book a consultation for your wedding look",
+    }
+
+
+def _core_only_summary():
+    """Only 5 core fields filled — should allow draft_ready but not approval_ready."""
+    return {
+        "profession_name": "Beauty Artist",      # industry
+        "location_focus": "Viman Nagar, Pune",   # locality
+        "audience": "Brides in Viman Nagar",     # target_audience
+        "business_goal": "Drive bookings",        # objective
+        "cta": "Book a consultation",             # offer
+    }
+
+
+def _insufficient_summary():
+    """Only 2 fields filled — should not allow any generation."""
+    return {
+        "profession_name": "Beauty Artist",
+        "location_focus": "Pune",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 1: When LLM returns themes + user asks for table → table is produced
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_table_generated_when_llm_returns_derived_themes_and_user_asks_for_table(test_client, monkeypatch):
+    """The happy path: LLM returns themes, user says 'give me themes in table format'
+    → auto_generated_draft should contain a table with actual theme rows."""
+    monkeypatch.setenv("PAYMENTS_MODE", "coupon")
+    monkeypatch.setenv("PERSISTENCE_MODE", "memory")
+    monkeypatch.setenv("CAMPAIGN_PERSISTENCE_MODE", "memory")
+
+    hired_instance_id = _create_marketing_hire(test_client, customer_id="cust-table-happy")
+
+    import api.v1.digital_marketing_activation as dma_module
+
+    monkeypatch.setattr(dma_module, "get_grok_client", lambda: object())
+    monkeypatch.setattr(
+        dma_module,
+        "grok_complete",
+        lambda *args, **kwargs: json.dumps({
+            "assistant_message": "Here is your content calendar.",
+            "status": "approval_ready",
+            "summary": _full_summary(),
+            "master_theme": "Bridal beauty authority in Viman Nagar",
+            "derived_themes": [
+                {"title": "Bridal Tutorials", "description": "Step-by-step bridal looks", "frequency": "weekly", "pillar": "Education"},
+                {"title": "Transformations", "description": "Before/after reveals", "frequency": "weekly", "pillar": "Proof"},
+                {"title": "Client Stories", "description": "Real bride testimonials", "frequency": "biweekly", "pillar": "Trust"},
+            ],
+            "checkpoint_summary": "All fields locked.",
+            "current_focus_question": "",
+            "next_step_options": ["Approve this direction"],
+            "time_saving_note": "Ready to go.",
+        }),
+    )
+
+    response = test_client.post(
+        f"/api/v1/digital-marketing-activation/{hired_instance_id}/generate-theme-plan",
+        headers={"Authorization": "Bearer test-token"},
+        json={
+            "campaign_setup": {
+                "strategy_workshop": {
+                    "pending_input": "give me actual themes in table format",
+                    "messages": [
+                        {"role": "user", "content": "give me actual themes in table format"},
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert len(body["derived_themes"]) >= 2, f"Expected themes but got: {body['derived_themes']}"
+    assert body["auto_generated_draft"] is not None, "Expected auto_generated_draft but got None"
+    draft = body["auto_generated_draft"]
+    assert len(draft.get("posts", [])) >= 1, "Expected at least one post in auto_generated_draft"
+
+    # Verify the table post has actual content, not a placeholder
+    table_post = draft["posts"][0]
+    assert "Bridal Tutorials" in table_post["text"], f"Table should contain theme titles, got: {table_post['text'][:200]}"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: LLM returns empty themes + user asks for table → targeted LLM call fires
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_targeted_theme_generation_when_llm_returns_empty_themes_but_core_fields_filled(test_client, monkeypatch):
+    """The bug scenario: LLM returns only conversational text with empty derived_themes,
+    but user asked for a table and core fields are filled → second LLM call should generate themes."""
+    monkeypatch.setenv("PAYMENTS_MODE", "coupon")
+    monkeypatch.setenv("PERSISTENCE_MODE", "memory")
+    monkeypatch.setenv("CAMPAIGN_PERSISTENCE_MODE", "memory")
+
+    hired_instance_id = _create_marketing_hire(test_client, customer_id="cust-table-empty-themes")
+
+    import api.v1.digital_marketing_activation as dma_module
+
+    # First call: LLM returns conversational filler with no themes (the bug)
+    # Second call: targeted theme generation returns actual themes
+    call_count = {"n": 0}
+
+    def mock_grok_complete(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # First call: conversation response with empty themes (simulates the bug)
+            return json.dumps({
+                "assistant_message": "I'm delighted to provide the actual themes for April 2026.",
+                "status": "approval_ready",
+                "summary": _core_only_summary(),
+                "master_theme": "Content plan for Acme Health",
+                "derived_themes": [],  # BUG: empty!
+                "checkpoint_summary": "Working on it.",
+                "current_focus_question": "",
+                "next_step_options": [],
+                "time_saving_note": "",
+            })
+        else:
+            # Second call: targeted theme generation succeeds
+            return json.dumps({
+                "master_theme": "Bridal beauty in Viman Nagar",
+                "derived_themes": [
+                    {"title": "Bridal Tutorials", "description": "Step-by-step looks", "frequency": "weekly", "pillar": "Education"},
+                    {"title": "Transformations", "description": "Before/after reveals", "frequency": "weekly", "pillar": "Proof"},
+                ],
+            })
+
+    monkeypatch.setattr(dma_module, "get_grok_client", lambda: object())
+    monkeypatch.setattr(dma_module, "grok_complete", mock_grok_complete)
+
+    response = test_client.post(
+        f"/api/v1/digital-marketing-activation/{hired_instance_id}/generate-theme-plan",
+        headers={"Authorization": "Bearer test-token"},
+        json={
+            "campaign_setup": {
+                "strategy_workshop": {
+                    "pending_input": "ok, give me actual themes in table format",
+                    "messages": [
+                        {"role": "user", "content": "ok, give me actual themes in table format"},
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    # The second LLM call should have fired
+    assert call_count["n"] >= 2, f"Expected 2+ LLM calls (second for theme gen), got {call_count['n']}"
+
+    # Should have actual themes now
+    assert len(body["derived_themes"]) >= 2, f"Expected themes from targeted call, got: {body['derived_themes']}"
+
+    # auto_generated_draft should exist
+    assert body["auto_generated_draft"] is not None, "Expected auto_generated_draft with table"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Insufficient fields + table request → clear field request, no table
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_insufficient_fields_returns_clear_field_request_not_filler(test_client, monkeypatch):
+    """When fewer than 5 core fields are filled and user asks for a table,
+    the DMA should explain what's missing and why — not produce filler text."""
+    monkeypatch.setenv("PAYMENTS_MODE", "coupon")
+    monkeypatch.setenv("PERSISTENCE_MODE", "memory")
+    monkeypatch.setenv("CAMPAIGN_PERSISTENCE_MODE", "memory")
+
+    hired_instance_id = _create_marketing_hire(test_client, customer_id="cust-table-insufficient")
+
+    import api.v1.digital_marketing_activation as dma_module
+
+    monkeypatch.setattr(dma_module, "get_grok_client", lambda: object())
+    monkeypatch.setattr(
+        dma_module,
+        "grok_complete",
+        lambda *args, **kwargs: json.dumps({
+            "assistant_message": "To build your content calendar I need target_audience and objective.",
+            "status": "approval_ready",
+            "summary": _insufficient_summary(),
+            "master_theme": "",
+            "derived_themes": [],
+            "checkpoint_summary": "",
+            "current_focus_question": "What audience are you targeting?",
+            "next_step_options": ["Define audience", "Set objective"],
+            "time_saving_note": "",
+        }),
+    )
+
+    response = test_client.post(
+        f"/api/v1/digital-marketing-activation/{hired_instance_id}/generate-theme-plan",
+        headers={"Authorization": "Bearer test-token"},
+        json={
+            "campaign_setup": {
+                "strategy_workshop": {
+                    "pending_input": "give me themes in table format",
+                    "messages": [
+                        {"role": "user", "content": "give me themes in table format"},
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    workshop = body["workspace"]["campaign_setup"]["strategy_workshop"]
+
+    # Should be in discovery, not approval_ready
+    assert workshop["status"] == "discovery", f"Expected discovery but got {workshop['status']}"
+
+    # The current_focus_question should mention missing fields, not generic filler
+    focus_q = workshop.get("current_focus_question", "")
+    assert focus_q, "Expected a current_focus_question about missing fields"
+
+    # auto_generated_draft should NOT exist (not enough fields)
+    # The table can't be generated without core fields
+    assert body["auto_generated_draft"] is None or body["auto_generated_draft"] == {}, \
+        f"Should not generate table with insufficient fields, got: {body.get('auto_generated_draft')}"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Core fields filled → status becomes draft_ready (not forced to discovery)
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_core_fields_filled_allows_draft_ready_status(test_client, monkeypatch):
+    """When 5 core fields are filled but < 9 total, status should be draft_ready,
+    not forced back to discovery."""
+    monkeypatch.setenv("PAYMENTS_MODE", "coupon")
+    monkeypatch.setenv("PERSISTENCE_MODE", "memory")
+    monkeypatch.setenv("CAMPAIGN_PERSISTENCE_MODE", "memory")
+
+    hired_instance_id = _create_marketing_hire(test_client, customer_id="cust-table-draft-ready")
+
+    import api.v1.digital_marketing_activation as dma_module
+
+    monkeypatch.setattr(dma_module, "get_grok_client", lambda: object())
+    monkeypatch.setattr(
+        dma_module,
+        "grok_complete",
+        lambda *args, **kwargs: json.dumps({
+            "assistant_message": "Here are your initial themes based on what I know so far.",
+            "status": "approval_ready",
+            "summary": _core_only_summary(),
+            "master_theme": "Bridal beauty in Viman Nagar",
+            "derived_themes": [
+                {"title": "Tutorials", "description": "Bridal looks", "frequency": "weekly"},
+                {"title": "Testimonials", "description": "Client stories", "frequency": "weekly"},
+            ],
+            "checkpoint_summary": "Core strategy locked.",
+            "current_focus_question": "",
+            "next_step_options": ["Approve", "Refine"],
+            "time_saving_note": "Draft ready.",
+        }),
+    )
+
+    response = test_client.post(
+        f"/api/v1/digital-marketing-activation/{hired_instance_id}/generate-theme-plan",
+        headers={"Authorization": "Bearer test-token"},
+        json={
+            "campaign_setup": {
+                "strategy_workshop": {
+                    "pending_input": "give me themes",
+                    "messages": [],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    workshop = body["workspace"]["campaign_setup"]["strategy_workshop"]
+
+    # With 5/11 fields and LLM saying approval_ready → should become draft_ready, not discovery
+    assert workshop["status"] == "draft_ready", f"Expected draft_ready but got {workshop['status']}"
+    assert len(body["derived_themes"]) >= 2
+
+
+# ---------------------------------------------------------------------------
+# Test 5: System prompt includes field purposes and DELIVERABLE REQUEST RULE
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_system_prompt_contains_field_purposes_and_gated_deliverable_rule():
+    """The system prompt must contain the gated deliverable rule and field purpose reference."""
+    import api.v1.digital_marketing_activation as dma_module
+
+    prompt_json = dma_module._theme_workshop_prompt(
+        {
+            "brand_name": "Test Brand",
+            "location": "Pune",
+            "offerings_services": ["Makeup"],
+            "platforms_enabled": ["youtube"],
+        },
+        {
+            "strategy_workshop": {
+                "messages": [],
+                "pending_input": "give me themes",
+            },
+        },
+    )
+    prompt = json.loads(prompt_json)
+
+    checklist = prompt["workshop_state"]["required_fields_checklist"]
+
+    # Must have core_fields and field_purposes
+    assert "core_fields" in checklist, "Missing core_fields in checklist"
+    assert "core_missing" in checklist, "Missing core_missing in checklist"
+    assert "can_generate_draft" in checklist, "Missing can_generate_draft in checklist"
+    assert "field_purposes" in checklist, "Missing field_purposes in checklist"
+
+    # field_purposes should explain why missing fields matter
+    for field, purpose in checklist["field_purposes"].items():
+        assert len(purpose) > 10, f"Field purpose for '{field}' is too short: '{purpose}'"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Readiness gate includes core_filled_count in brief_progress
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_brief_progress_includes_core_field_tracking():
+    """_parse_theme_workshop_response should include core field tracking in brief_progress."""
+    import api.v1.digital_marketing_activation as dma_module
+
+    raw = json.dumps({
+        "assistant_message": "Here are your themes.",
+        "status": "approval_ready",
+        "summary": _core_only_summary(),
+        "master_theme": "Test theme",
+        "derived_themes": [{"title": "T1", "description": "D1", "frequency": "weekly"}],
+        "checkpoint_summary": "Done.",
+        "current_focus_question": "",
+        "next_step_options": [],
+        "time_saving_note": "",
+    })
+
+    _master, _derived, workshop = dma_module._parse_theme_workshop_response(
+        raw,
+        workspace={"brand_name": "Test"},
+        existing_workshop={"messages": [], "summary": {}, "follow_up_questions": [], "status": "discovery"},
+        pending_input="give me a plan",
+    )
+
+    bp = workshop["brief_progress"]
+    assert "core_filled_count" in bp, "Missing core_filled_count in brief_progress"
+    assert "can_generate_draft" in bp, "Missing can_generate_draft in brief_progress"
+    assert bp["core_filled_count"] == 5, f"Expected 5 core fields filled, got {bp['core_filled_count']}"
+    assert bp["can_generate_draft"] is True
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Conversational-only response with table request = FAILURE scenario
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_conversational_only_response_does_not_silently_pass_as_table(test_client, monkeypatch):
+    """If LLM returns only 'I'm delighted to provide...' with no themes and insufficient fields,
+    the response must NOT contain an auto_generated_draft pretending to be a table."""
+    monkeypatch.setenv("PAYMENTS_MODE", "coupon")
+    monkeypatch.setenv("PERSISTENCE_MODE", "memory")
+    monkeypatch.setenv("CAMPAIGN_PERSISTENCE_MODE", "memory")
+
+    hired_instance_id = _create_marketing_hire(test_client, customer_id="cust-table-filler")
+
+    import api.v1.digital_marketing_activation as dma_module
+
+    monkeypatch.setattr(dma_module, "get_grok_client", lambda: object())
+    monkeypatch.setattr(
+        dma_module,
+        "grok_complete",
+        lambda *args, **kwargs: json.dumps({
+            "assistant_message": "I'm delighted to provide the actual themes for April 2026, tailored for Viman Nagar brides on YouTube.",
+            "status": "discovery",
+            "summary": _insufficient_summary(),
+            "master_theme": "",
+            "derived_themes": [],
+            "checkpoint_summary": "",
+            "current_focus_question": "",
+            "next_step_options": [],
+            "time_saving_note": "",
+        }),
+    )
+
+    response = test_client.post(
+        f"/api/v1/digital-marketing-activation/{hired_instance_id}/generate-theme-plan",
+        headers={"Authorization": "Bearer test-token"},
+        json={
+            "campaign_setup": {
+                "strategy_workshop": {
+                    "pending_input": "give me themes in table format",
+                    "messages": [
+                        {"role": "user", "content": "give me themes in table format"},
+                    ],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+
+    # No table should be produced when there are no themes and insufficient fields
+    if body["auto_generated_draft"] is not None:
+        posts = body["auto_generated_draft"].get("posts", [])
+        for post in posts:
+            # If a table post exists, it must NOT be just a generic single-row placeholder
+            if post.get("artifact_type") == "table":
+                meta = post.get("artifact_metadata", {})
+                table_rows = meta.get("table_preview", {}).get("rows", [])
+                # A single-row table with just the master theme = useless placeholder
+                if len(table_rows) <= 1:
+                    theme_val = table_rows[0].get("Theme", "") if table_rows else ""
+                    assert "Content plan for" not in theme_val, (
+                        f"Got a useless placeholder table instead of real themes: {table_rows}"
+                    )


### PR DESCRIPTION
## Problem
When users asked for a content calendar table, the DMA returned conversational filler text
("I'm delighted to provide the actual themes...") with no actual table or themes.

## Root Cause
| Root cause | Impact | Fix |
|---|---|---|
| System prompt said "produce deliverable immediately" but response contract had no mechanism for it | LLM returned filler in assistant_message with empty derived_themes | Gated deliverable rule: only ask for themes when 5+ core fields are filled |
| `_build_auto_draft` read empty `derived_themes` and silently produced nothing | User sees conversational text but no table | Targeted second LLM call when themes empty + core fields present |
| Auto-draft block ran even during discovery status (fallback master_theme was non-empty) | Placeholder tables with single generic row | Guard: only auto-draft when status >= draft_ready |

## Changes
- **5 core required fields** as minimum bar for draft generation (industry, locality, target_audience, objective, offer)
- **Field purpose reference** in system prompt so LLM explains why fields matter
- **Two-tier readiness**: 5 core = draft_ready, 9 total = approval_ready
- **Targeted second LLM call** when themes empty but core fields filled
- **Auto-draft guard**: only runs when workshop status is draft_ready/approval_ready/approved
- **7 new test cases** covering the exact failure scenario + edge cases

## Test Results
- 7 new tests: all passing
- 8 existing DMA tests: all passing (no regressions)
- Total: 15/15 passing