### PR TITLE
fix(CP-FE): deduplicate DMA message + surface publish error details

### DIFF
--- a/src/CP/BackEnd/requirements-dev.txt
+++ b/src/CP/BackEnd/requirements-dev.txt
@@ -1,8 +1,8 @@
 # Development and Testing Dependencies
 
 # Testing
-pytest==7.4.4
-pytest-asyncio==0.23.3
+pytest==9.0.3
+pytest-asyncio==1.3.0
 pytest-cov==4.1.0
 pytest-mock==3.12.0
 httpx==0.26.0  # For TestClient

--- a/src/CP/BackEnd/requirements.txt
+++ b/src/CP/BackEnd/requirements.txt
@@ -38,8 +38,8 @@ opentelemetry-instrumentation-httpx==0.43b0
 opentelemetry-instrumentation-sqlalchemy==0.43b0
 
 # Testing
-pytest==7.4.4
-pytest-asyncio==0.21.1
+pytest==9.0.3
+pytest-asyncio==1.3.0
 pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-bdd==7.1.2

--- a/src/CP/FrontEnd/src/components/DigitalMarketingActivationWizard.tsx
+++ b/src/CP/FrontEnd/src/components/DigitalMarketingActivationWizard.tsx
@@ -441,6 +441,7 @@ export function DigitalMarketingActivationWizard({
   const [outputItemStatuses, setOutputItemStatuses] = useState<Record<string, ArtifactStatus>>({})
   const [outputItemActions, setOutputItemActions] = useState<Record<string, 'idle' | 'loading' | 'done' | 'error'>>({})
   const [outputItemReceipts, setOutputItemReceipts] = useState<Record<string, string>>({})
+  const [actionErrorMessages, setActionErrorMessages] = useState<Record<string, string>>({})
   const [expandedOutputItems, setExpandedOutputItems] = useState<Record<string, boolean>>({})
   const chatScrollRef = useRef<HTMLDivElement | null>(null)
   const [activeBriefSection, setActiveBriefSection] = useState<'brief' | 'objective' | 'status' | 'next' | 'controls' | 'output' | null>('brief')
@@ -794,10 +795,9 @@ export function DigitalMarketingActivationWizard({
     }
 
     const latestAssistantMessage = String(strategyWorkshop.assistant_message || '').trim()
-    const lastMessage = messages[messages.length - 1]
     if (
       latestAssistantMessage
-      && (lastMessage?.role !== 'assistant' || lastMessage.content !== latestAssistantMessage)
+      && !messages.some((m) => m.role === 'assistant' && m.content === latestAssistantMessage)
     ) {
       messages.push({ role: 'assistant', content: latestAssistantMessage })
     }
@@ -1430,8 +1430,9 @@ export function DigitalMarketingActivationWizard({
         )
       )
       setPostActionStatus((s) => ({ ...s, [post.post_id]: 'done' }))
-    } catch {
+    } catch (err: any) {
       setPostActionStatus((s) => ({ ...s, [post.post_id]: 'error' }))
+      setActionErrorMessages((s) => ({ ...s, [post.post_id]: err?.message || 'Publish failed' }))
     }
   }
 
@@ -1504,8 +1505,9 @@ export function DigitalMarketingActivationWizard({
         )
       )
       setOutputItemActions((s) => ({ ...s, [post.post_id]: 'done' }))
-    } catch {
+    } catch (err: any) {
       setOutputItemActions((s) => ({ ...s, [post.post_id]: 'error' }))
+      setActionErrorMessages((s) => ({ ...s, [post.post_id]: err?.message || 'Publish failed' }))
     }
   }
 
@@ -1703,7 +1705,7 @@ export function DigitalMarketingActivationWizard({
                       ) : null}
                       {actionStatus === 'loading' ? <Spinner size="tiny" /> : null}
                       {actionStatus === 'error' ? (
-                        <span style={{ color: '#ef4444', fontSize: '0.82rem' }}>Action failed — try again</span>
+                        <span style={{ color: '#ef4444', fontSize: '0.82rem' }}>{actionErrorMessages[post.post_id] || 'Action failed'} — try again</span>
                       ) : null}
                     </div>
                   ) : null}
@@ -1889,7 +1891,7 @@ export function DigitalMarketingActivationWizard({
                             </Button>
                           ) : null}
                           {actionStatus === 'loading' ? <Spinner size="tiny" /> : null}
-                          {actionStatus === 'error' ? <span style={{ color: '#ef4444', fontSize: '0.82rem' }}>Action failed</span> : null}
+                          {actionStatus === 'error' ? <span style={{ color: '#ef4444', fontSize: '0.82rem' }}>{actionErrorMessages[post.post_id] || 'Action failed'}</span> : null}
                         </div>
                       ) : null}
                       {isPosted ? <Badge appearance="filled" color="success">Published</Badge> : null}
@@ -2061,7 +2063,7 @@ export function DigitalMarketingActivationWizard({
                         </>
                       ) : null}
                       {status === 'loading' ? <Spinner size="tiny" /> : null}
-                      {status === 'error' ? <span style={{ color: '#ef4444', fontSize: '0.82rem' }}>Action failed</span> : null}
+                      {status === 'error' ? <span style={{ color: '#ef4444', fontSize: '0.82rem' }}>{actionErrorMessages[post.post_id] || 'Action failed'}</span> : null}
                     </div>
                   ) : null}
                 </div>

--- a/src/PP/BackEnd/requirements-test.txt
+++ b/src/PP/BackEnd/requirements-test.txt
@@ -1,5 +1,5 @@
-pytest==7.4.4
-pytest-asyncio==0.23.3
+pytest==9.0.3
+pytest-asyncio==1.3.0
 pytest-cov==4.1.0
 ruff>=0.3.0
 mypy>=1.8.0

--- a/src/PP/BackEnd/requirements.txt
+++ b/src/PP/BackEnd/requirements.txt
@@ -34,7 +34,7 @@ opentelemetry-instrumentation-httpx==0.43b0
 python-dotenv==1.0.0
 
 # Testing
-pytest==7.4.4
-pytest-asyncio==0.21.1
+pytest==9.0.3
+pytest-asyncio==1.3.0
 pytest-cov==4.1.0
 pytest-mock==3.12.0

--- a/src/Plant/BackEnd/requirements-test.txt
+++ b/src/Plant/BackEnd/requirements-test.txt
@@ -1,6 +1,6 @@
 # Test-only dependencies (minimal for validation)
-pytest==7.4.4
-pytest-asyncio==0.23.3
+pytest==9.0.3
+pytest-asyncio==1.3.0
 pytest-cov==4.1.0
 pytest-benchmark==4.0.0
 testcontainers==3.7.1

--- a/src/Plant/BackEnd/requirements.txt
+++ b/src/Plant/BackEnd/requirements.txt
@@ -46,8 +46,8 @@ pyyaml==6.0.1
 tenacity==8.2.3  # Retry logic with exponential backoff
 
 # Testing
-pytest==7.4.4
-pytest-asyncio==0.23.3
+pytest==9.0.3
+pytest-asyncio==1.3.0
 pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-benchmark==4.0.0

--- a/src/Plant/Gateway/requirements-dev.txt
+++ b/src/Plant/Gateway/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Development / test-only dependencies for Plant Gateway
-pytest==7.4.4
-pytest-asyncio==0.23.3
+pytest==9.0.3
+pytest-asyncio==1.3.0
 pytest-cov==4.1.0
 pytest-mock==3.12.0
 ruff>=0.3.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,8 +2,8 @@
 # Consolidated requirements for all test types
 
 # Core Testing Framework
-pytest==7.4.4
-pytest-asyncio==0.23.3
+pytest==9.0.3
+pytest-asyncio==1.3.0
 pytest-cov==4.1.0
 pytest-mock==3.12.0
 pytest-benchmark==4.0.0


### PR DESCRIPTION
## Changes

### 1. Deduplicate DMA message
`chatMessages` memo now checks entire messages array (not just last position) before appending `assistant_message`, preventing the duplicate that appeared before and after the draft card.

### 2. Surface publish error details
All 3 'Action failed' UI locations now display the actual backend error message (e.g. credential not found) instead of generic text.

### 3. Fix CVE-2025-71176 — upgrade pytest 7.4.4 → 9.0.3
`pytest 7.4.4` has CVE-2025-71176 (/tmp/pytest-of-{user} symlink attack, fix version 9.0.3). Also upgraded `pytest-asyncio` from 0.21.1/0.23.3 to 1.3.0 for pytest 9 compatibility. All 8 requirements files updated.

## Root Cause

| Issue | Root cause | Fix |
|-------|-----------|-----|
| DMA text appears twice | `chatMessages` only compared against last message; `[DRAFT_POSTS:...]` injection pushed it out of position | `messages.some()` — checks full array |
| Generic 'Action failed' on Publish | Catch blocks discarded `GatewayApiError.message` | Capture `err.message` into `actionErrorMessages` state |
| CI pip-audit failure | `pytest==7.4.4` has CVE-2025-71176 | Upgraded to `pytest==9.0.3` + `pytest-asyncio==1.3.0` |

## Testing
- CP Backend: 375 passed (Docker)
- Plant Backend: 1244 passed (Docker)
- PP Backend: 145 passed (Docker)
- Frontend: 41 passed (Docker)
