### PR TITLE
fix(plant): wire DatabaseCredentialResolver into all YouTube publish paths

### DIFF
--- a/src/Plant/BackEnd/agent_mold/skills/adapters_youtube.py
+++ b/src/Plant/BackEnd/agent_mold/skills/adapters_youtube.py
@@ -30,8 +30,20 @@ class YouTubeAdapter(DestinationAdapter):
         customer_id = metadata.get("customer_id", "")
         credential_ref = inp.credential_ref or metadata.get("credential_ref", "")
 
-        client = YouTubeClient(customer_id=customer_id)
+        # Use DatabaseCredentialResolver with a fresh DB session so the publish
+        # path resolves credentials from Plant DB + Secret Manager instead of
+        # the old CP HTTP round-trip (which relied on an ephemeral JSONL file).
+        from core.database import _connector as db_connector
+        from services.social_credential_resolver import DatabaseCredentialResolver
+
+        resolver = None
+        db_session = None
         try:
+            await db_connector.initialize()
+            db_session = db_connector.async_session_factory()
+            resolver = DatabaseCredentialResolver(db_session)
+
+            client = YouTubeClient(customer_id=customer_id, credential_resolver=resolver)
             result = await client.post_text(
                 credential_ref=credential_ref,
                 text=inp.post.content_text,
@@ -55,3 +67,6 @@ class YouTubeAdapter(DestinationAdapter):
                 success=False,
                 error=str(exc),
             )
+        finally:
+            if db_session is not None:
+                await db_session.close()

--- a/src/Plant/BackEnd/agent_mold/skills/adapters_youtube.py
+++ b/src/Plant/BackEnd/agent_mold/skills/adapters_youtube.py
@@ -25,6 +25,13 @@ class YouTubeAdapter(DestinationAdapter):
 
     DESTINATION_TYPE = "youtube"
 
+    async def _open_db_session(self):
+        """Create a fresh async DB session for credential resolution."""
+        from core.database import _connector as db_connector
+
+        await db_connector.initialize()
+        return db_connector.async_session_factory()
+
     async def publish(self, inp: PublishInput) -> PublishReceipt:
         metadata = inp.post.destination.metadata or {}
         customer_id = metadata.get("customer_id", "")
@@ -33,14 +40,11 @@ class YouTubeAdapter(DestinationAdapter):
         # Use DatabaseCredentialResolver with a fresh DB session so the publish
         # path resolves credentials from Plant DB + Secret Manager instead of
         # the old CP HTTP round-trip (which relied on an ephemeral JSONL file).
-        from core.database import _connector as db_connector
         from services.social_credential_resolver import DatabaseCredentialResolver
 
-        resolver = None
         db_session = None
         try:
-            await db_connector.initialize()
-            db_session = db_connector.async_session_factory()
+            db_session = await self._open_db_session()
             resolver = DatabaseCredentialResolver(db_session)
 
             client = YouTubeClient(customer_id=customer_id, credential_resolver=resolver)

--- a/src/Plant/BackEnd/api/v1/marketing_drafts.py
+++ b/src/Plant/BackEnd/api/v1/marketing_drafts.py
@@ -34,6 +34,7 @@ from services.policy_denial_audit import (
     get_policy_denial_audit_store,
 )
 from services.marketing_credential_resolver import resolve_youtube_secret_ref
+from services.social_credential_resolver import DatabaseCredentialResolver
 from worker.tasks.media_generation_tasks import enqueue_media_generation_job
 
 router = waooaw_router(prefix="/marketing", tags=["marketing"])
@@ -630,7 +631,10 @@ async def execute_draft_post(
         try:
             from integrations.social.youtube_client import YouTubeClient
 
-            client = YouTubeClient(customer_id=batch.customer_id)
+            client = YouTubeClient(
+                customer_id=batch.customer_id,
+                credential_resolver=DatabaseCredentialResolver(db),
+            )
             if post.artifact_type in {"video", "video_audio"} and post.artifact_uri:
                 result = await client.post_short(
                     credential_ref=effective_credential_ref,

--- a/src/Plant/BackEnd/tests/test_publisher_engine.py
+++ b/src/Plant/BackEnd/tests/test_publisher_engine.py
@@ -193,6 +193,9 @@ async def test_youtube_public_release_requires_explicit_customer_action():
                 },
             )()
         ),
+    ), patch(
+        "agent_mold.skills.adapters_youtube.YouTubeAdapter._open_db_session",
+        new=AsyncMock(return_value=AsyncMock()),
     ):
         allowed = await engine.publish(
             PublishInput(

--- a/src/Plant/BackEnd/tests/unit/test_adapters_youtube.py
+++ b/src/Plant/BackEnd/tests/unit/test_adapters_youtube.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -29,6 +29,13 @@ def _make_publish_input() -> PublishInput:
     )
 
 
+def _mock_db_session():
+    """Return an AsyncMock that behaves like an AsyncSession."""
+    session = AsyncMock()
+    session.close = AsyncMock()
+    return session
+
+
 @pytest.mark.asyncio
 async def test_youtube_adapter_publish_success():
     now = datetime.now(timezone.utc)
@@ -45,6 +52,8 @@ async def test_youtube_adapter_publish_success():
                 raw_response={"id": "yt123"},
             )
         ),
+    ), patch.object(
+        YouTubeAdapter, "_open_db_session", new=AsyncMock(return_value=_mock_db_session()),
     ):
         receipt = await YouTubeAdapter().publish(_make_publish_input())
 
@@ -68,6 +77,8 @@ async def test_youtube_adapter_publish_failure():
                 error_code="POST_FAILED",
             )
         ),
+    ), patch.object(
+        YouTubeAdapter, "_open_db_session", new=AsyncMock(return_value=_mock_db_session()),
     ):
         receipt = await YouTubeAdapter().publish(_make_publish_input())
 


### PR DESCRIPTION
## Problem

After PR #1061 (credential DB migration + content creator service) was merged and deployed, YouTube publish still fails with:

```
CredentialResolutionError: Credential not found: CRED-4cc01BQfTUfKIMfc for customer 33eb5ebb-...
```

### Root Causes

| Root Cause | Impact | Fix |
|---|---|---|
| `execute_draft_post()` in `marketing_drafts.py` constructs `YouTubeClient` without a resolver → falls back to old `CPSocialCredentialResolver` → HTTP to CP's ephemeral JSONL (wiped on restart) | Draft post execution always fails | Pass `DatabaseCredentialResolver(db)` to `YouTubeClient` |
| `YouTubeAdapter.publish()` in `adapters_youtube.py` constructs `YouTubeClient` without a resolver (PublisherEngine pattern) | Campaign/scheduler publish always fails | Create DB session from `core.database._connector`, build resolver, close session in finally |
| Migration 039 (`credential_ref`, `secret_manager_ref` columns) never applied to Cloud SQL demo | `DatabaseCredentialResolver` would fail even if wired correctly | Applied via psql; backfilled 2 existing rows with GCP SM refs |

## Changes

- **`api/v1/marketing_drafts.py`**: Pass `DatabaseCredentialResolver(db)` to `YouTubeClient` in `execute_draft_post()`
- **`agent_mold/skills/adapters_youtube.py`**: Create dedicated DB session, build `DatabaseCredentialResolver`, close session in `finally` block
- **Cloud SQL demo**: Migration 039 applied + credential data backfilled (`credential_ref` + `secret_manager_ref` for 2 rows)

## Testing

- 1265 unit tests pass, 0 failures
- All 47 credential-specific tests pass (`test_credential_resolver`, `test_adapters_youtube`, `test_database_credential_store`, `test_publisher_engine`, `test_youtube_publisher`)
