### PR TITLE
fix(dma): youtube publish + staged theme→content workflow

### DIFF
--- a/src/CP/BackEnd/api/marketing_review.py
+++ b/src/CP/BackEnd/api/marketing_review.py
@@ -264,7 +264,7 @@ async def create_content_batch_from_theme(
     return resp.json if isinstance(resp.json, dict) else {}
 
 
-
+class ExecuteDraftPostInput(BaseModel):
     post_id: str = Field(..., min_length=1)
     agent_id: str = Field(..., min_length=1)
     purpose: Optional[str] = None

--- a/src/CP/BackEnd/api/marketing_review.py
+++ b/src/CP/BackEnd/api/marketing_review.py
@@ -189,6 +189,8 @@ class CreateDraftBatchInput(BaseModel):
     agent_id: str = Field(..., min_length=1)
     hired_instance_id: Optional[str] = None
     campaign_id: Optional[str] = None
+    batch_type: str = "direct"
+    parent_batch_id: Optional[str] = None
     theme: str
     brand_name: str
     brief_summary: Optional[str] = None
@@ -229,7 +231,40 @@ async def create_draft_batch(
     return resp.json if isinstance(resp.json, dict) else {}
 
 
-class ExecuteDraftPostInput(BaseModel):
+class CreateContentFromThemeInput(BaseModel):
+    class ArtifactRequestInput(BaseModel):
+        artifact_type: str = Field(..., min_length=1)
+        prompt: str = Field(..., min_length=1)
+        metadata: Dict[str, Any] = Field(default_factory=dict)
+
+    youtube_credential_ref: Optional[str] = None
+    youtube_visibility: str = "private"
+    public_release_requested: bool = False
+    requested_artifacts: Optional[List[ArtifactRequestInput]] = None
+
+
+@router.post("/draft-batches/{batch_id}/create-content-batch", response_model=Dict[str, Any])
+async def create_content_batch_from_theme(
+    batch_id: str,
+    body: CreateContentFromThemeInput,
+    request: Request,
+    current_user: User = Depends(get_current_user),
+    plant: PlantGatewayClient = Depends(get_plant_gateway_client),
+) -> Dict[str, Any]:
+    resp = await plant.request_json(
+        method="POST",
+        path=f"api/v1/marketing/draft-batches/{batch_id}/create-content-batch",
+        headers=_forward_headers(request),
+        json_body=body.model_dump(exclude_none=True),
+    )
+    if resp.status_code >= 500:
+        raise HTTPException(status_code=503, detail="UPSTREAM_ERROR")
+    if resp.status_code not in (200, 201):
+        raise HTTPException(status_code=resp.status_code, detail=resp.json)
+    return resp.json if isinstance(resp.json, dict) else {}
+
+
+
     post_id: str = Field(..., min_length=1)
     agent_id: str = Field(..., min_length=1)
     purpose: Optional[str] = None

--- a/src/CP/BackEnd/tests/test_marketing_review_routes.py
+++ b/src/CP/BackEnd/tests/test_marketing_review_routes.py
@@ -304,3 +304,33 @@ def test_marketing_execute_draft_post_proxy(client, auth_headers, monkeypatch, t
 
     app.dependency_overrides.clear()
 
+
+# ---------------------------------------------------------------------------
+# Guard: ExecuteDraftPostInput class must be defined
+# (catches accidental deletion of the class header that caused 422 in CI)
+# ---------------------------------------------------------------------------
+
+def test_execute_draft_post_input_class_exists():
+    """ExecuteDraftPostInput must be importable and have the required fields.
+
+    If this class's header line is accidentally deleted, FastAPI can no longer
+    parse the request body and returns 422 for every /draft-posts/execute call.
+    """
+    from api.marketing_review import ExecuteDraftPostInput
+
+    fields = ExecuteDraftPostInput.model_fields
+    assert "post_id" in fields, "post_id missing from ExecuteDraftPostInput"
+    assert "agent_id" in fields, "agent_id missing from ExecuteDraftPostInput"
+    assert "intent_action" in fields, "intent_action missing from ExecuteDraftPostInput"
+    assert "approval_id" in fields, "approval_id missing from ExecuteDraftPostInput"
+
+
+def test_create_content_from_theme_input_class_exists():
+    """CreateContentFromThemeInput must exist for the staged workflow proxy endpoint."""
+    from api.marketing_review import CreateContentFromThemeInput, CreateDraftBatchInput
+
+    # CreateDraftBatchInput must carry batch_type and parent_batch_id
+    batch_fields = CreateDraftBatchInput.model_fields
+    assert "batch_type" in batch_fields
+    assert "parent_batch_id" in batch_fields
+

--- a/src/CP/FrontEnd/src/components/DigitalMarketingActivationWizard.tsx
+++ b/src/CP/FrontEnd/src/components/DigitalMarketingActivationWizard.tsx
@@ -27,6 +27,7 @@ import {
 } from '../services/digitalMarketingActivation.service'
 import {
   createDraftBatch,
+  createContentBatchFromTheme,
   listCustomerDraftBatches,
   executeDraftPost,
   approveDraftPost,
@@ -430,6 +431,10 @@ export function DigitalMarketingActivationWizard({
   const [youtubeValidationResult, setYoutubeValidationResult] = useState<ValidateYouTubeConnectionResponse | null>(null)
 
   const [generatedBatch, setGeneratedBatch] = useState<DraftBatch | null>(null)
+  // themeBatch: the most recently generated theme (table) batch awaiting approval
+  const [themeBatch, setThemeBatch] = useState<DraftBatch | null>(null)
+  const [contentCreating, setContentCreating] = useState(false)
+  const [contentCreateError, setContentCreateError] = useState<string | null>(null)
   const [draftPosts, setDraftPosts] = useState<DraftPost[]>([])
   const [draftGenerating, setDraftGenerating] = useState(false)
   const [draftGenerateError, setDraftGenerateError] = useState<string | null>(null)
@@ -1342,10 +1347,14 @@ export function DigitalMarketingActivationWizard({
     try {
       const agentId = String(draft?.agent_id || activeInstance?.agent_id || '').trim()
       const campaignId = activation?.workspace?.campaign_setup?.campaign_id || undefined
+      // If the only artifact requested is 'table', tag this as a theme batch (content plan for approval).
+      // Any other artifact combination is a direct content batch.
+      const isThemeBatch = selectedArtifactTypes.length > 0 && selectedArtifactTypes.every((t) => t === 'table')
       const batch = await createDraftBatch({
         agent_id: agentId,
         hired_instance_id: hiredInstanceId,
         campaign_id: campaignId ?? null,
+        batch_type: isThemeBatch ? 'theme' : 'direct',
         theme: masterTheme.trim() || brandName.trim(),
         brand_name: brandName.trim(),
         brief_summary: businessContext.trim() || undefined,
@@ -1359,6 +1368,9 @@ export function DigitalMarketingActivationWizard({
         channels: ['youtube'],
         requested_artifacts: requestedArtifacts,
       })
+      if (isThemeBatch) {
+        setThemeBatch(batch)
+      }
       setGeneratedBatch(batch)
       const ytPosts = batch.posts.filter((p) => p.channel === 'youtube')
       setDraftPosts(ytPosts)
@@ -1373,7 +1385,9 @@ export function DigitalMarketingActivationWizard({
       // Inject draft post cards into the chat thread
       if (ytPosts.length > 0) {
         const queuedCount = ytPosts.filter((p) => p.artifact_generation_status === 'queued').length
-        let msg = `Here ${ytPosts.length === 1 ? 'is your YouTube draft' : `are your ${ytPosts.length} YouTube drafts`}.`
+        const batchLabel = isThemeBatch ? 'theme plan' : 'YouTube draft'
+        let msg = `Here ${ytPosts.length === 1 ? `is your ${batchLabel}` : `are your ${ytPosts.length} ${batchLabel}s`}.`
+        if (isThemeBatch) msg += ' Approve the theme plan to unlock content creation.'
         if (queuedCount > 0) msg += ` ${queuedCount} media asset${queuedCount > 1 ? 's are' : ' is'} generating.`
         msg += `\n[DRAFT_POSTS:${ytPosts.map((p) => p.post_id).join(',')}]`
         setStrategyWorkshop((prev) => ({
@@ -1388,6 +1402,53 @@ export function DigitalMarketingActivationWizard({
       setDraftGenerateError(e?.message || 'Failed to generate YouTube draft.')
     } finally {
       setDraftGenerating(false)
+    }
+  }
+
+  // Whether the current theme batch has all posts approved — unlocks "Create Content" button
+  const isThemeBatchFullyApproved = Boolean(
+    themeBatch &&
+    themeBatch.posts.length > 0 &&
+    themeBatch.posts.every((p) => p.review_status === 'approved')
+  )
+
+  const handleCreateContentFromApprovedTheme = async () => {
+    if (!themeBatch || !isThemeBatchFullyApproved) return
+    setContentCreating(true)
+    setContentCreateError(null)
+    try {
+      const contentArtifacts = selectedArtifactTypes
+        .filter((t) => t !== 'table')
+        .map((artifactType) => ({
+          artifact_type: artifactType,
+          prompt: `Create a ${artifactType.replace('_', ' ')} asset for ${masterTheme.trim() || brandName.trim()}`,
+          metadata: { source: 'cp_dma_wizard', channel: 'youtube' },
+        }))
+      const contentBatch = await createContentBatchFromTheme(themeBatch.batch_id, {
+        youtube_credential_ref: youtubeCredentialRef,
+        youtube_visibility: 'private',
+        public_release_requested: false,
+        requested_artifacts: contentArtifacts.length > 0 ? contentArtifacts : undefined,
+      })
+      setGeneratedBatch(contentBatch)
+      const ytPosts = contentBatch.posts.filter((p) => p.channel === 'youtube')
+      setDraftPosts(ytPosts)
+      setPostActionStatus({})
+      setPostPublishReceipts({})
+      setOutputItems((prev) => {
+        const existingIds = new Set(prev.map((p) => p.post_id))
+        const fresh = ytPosts.filter((p) => !existingIds.has(p.post_id))
+        return fresh.length > 0 ? [...prev, ...fresh] : prev
+      })
+      const msg = `Content batch created from your approved theme. ${ytPosts.length} post${ytPosts.length !== 1 ? 's are' : ' is'} ready for review.\n[DRAFT_POSTS:${ytPosts.map((p) => p.post_id).join(',')}]`
+      setStrategyWorkshop((prev) => ({
+        ...prev,
+        messages: [...(prev.messages || []), { role: 'assistant' as const, content: msg }],
+      }))
+    } catch (e: any) {
+      setContentCreateError(e?.message || 'Failed to create content batch.')
+    } finally {
+      setContentCreating(false)
     }
   }
 
@@ -1970,21 +2031,36 @@ export function DigitalMarketingActivationWizard({
                 ))}
               </div>
             </div>
-            <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
+            <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center', flexWrap: 'wrap' }}>
               <Button
                 appearance="primary"
                 onClick={() => void handleGenerateYouTubeDraft()}
                 disabled={!canGenerateYouTubeDraft || readOnly}
                 data-testid="generate-youtube-draft-btn"
               >
-                {draftGenerating ? 'Generating…' : 'Generate YouTube Draft'}
+                {draftGenerating ? 'Generating…' : 'Generate Theme Plan'}
               </Button>
               {draftGenerating ? <Spinner size="tiny" /> : null}
+              {/* Show "Create Content" only after the theme batch is fully approved */}
+              {isThemeBatchFullyApproved && (
+                <Button
+                  appearance="primary"
+                  onClick={() => void handleCreateContentFromApprovedTheme()}
+                  disabled={contentCreating || readOnly}
+                  data-testid="create-content-from-theme-btn"
+                >
+                  {contentCreating ? 'Creating content…' : 'Create Content from Approved Theme'}
+                </Button>
+              )}
+              {contentCreating ? <Spinner size="tiny" /> : null}
             </div>
           </div>
         )}
         {draftGenerateError ? (
           <FeedbackMessage intent="error" title="Draft generation failed" message={draftGenerateError} />
+        ) : null}
+        {contentCreateError ? (
+          <FeedbackMessage intent="error" title="Content creation failed" message={contentCreateError} />
         ) : null}
 
         {draftPosts.length > 0 && (

--- a/src/CP/FrontEnd/src/services/marketingReview.service.ts
+++ b/src/CP/FrontEnd/src/services/marketingReview.service.ts
@@ -42,7 +42,7 @@ export type DraftPost = {
 
 export type DraftBatch = {
   batch_id: string
-  batch_type: string  // 'theme' | 'content' | 'direct'
+  batch_type?: string  // 'theme' | 'content' | 'direct'
   parent_batch_id?: string | null
   agent_id: string
   hired_instance_id?: string | null

--- a/src/CP/FrontEnd/src/services/marketingReview.service.ts
+++ b/src/CP/FrontEnd/src/services/marketingReview.service.ts
@@ -42,6 +42,8 @@ export type DraftPost = {
 
 export type DraftBatch = {
   batch_id: string
+  batch_type: string  // 'theme' | 'content' | 'direct'
+  parent_batch_id?: string | null
   agent_id: string
   hired_instance_id?: string | null
   customer_id?: string | null
@@ -56,6 +58,8 @@ export type CreateDraftBatchInput = {
   agent_id: string
   hired_instance_id?: string | null
   campaign_id?: string | null
+  batch_type?: string  // 'theme' | 'content' | 'direct'
+  parent_batch_id?: string | null
   theme: string
   brand_name: string
   brief_summary?: string | null
@@ -68,6 +72,13 @@ export type CreateDraftBatchInput = {
   youtube_visibility?: string
   public_release_requested?: boolean
   channels?: string[] | null
+  requested_artifacts?: DraftArtifactRequest[] | null
+}
+
+export type CreateContentFromThemeInput = {
+  youtube_credential_ref?: string | null
+  youtube_visibility?: string
+  public_release_requested?: boolean
   requested_artifacts?: DraftArtifactRequest[] | null
 }
 
@@ -148,4 +159,18 @@ export type ArtifactStatus = {
 
 export async function pollDraftPostArtifactStatus(postId: string): Promise<ArtifactStatus> {
   return gatewayRequestJson<ArtifactStatus>(`/cp/marketing/draft-posts/${postId}/artifact-status`)
+}
+
+export async function createContentBatchFromTheme(
+  themeBatchId: string,
+  input: CreateContentFromThemeInput
+): Promise<DraftBatch> {
+  return gatewayRequestJson<DraftBatch>(
+    `/cp/marketing/draft-batches/${themeBatchId}/create-content-batch`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    }
+  )
 }

--- a/src/Plant/BackEnd/api/v1/marketing_drafts.py
+++ b/src/Plant/BackEnd/api/v1/marketing_drafts.py
@@ -686,6 +686,14 @@ async def execute_draft_post(
         )
 
     batch, post = found
+    # Reject execution of posts that have been explicitly rejected by the customer
+    if post.review_status == "rejected":
+        raise PolicyEnforcementError(
+            "Draft post has been rejected and cannot be published",
+            reason="post_rejected",
+            details={"post_id": post_id, "review_status": post.review_status},
+        )
+
     correlation_id = body.correlation_id or str(uuid4())
     requested_approval_id = (body.approval_id or "").strip() or None
     stored_approval_id = (post.approval_id or "").strip() or None

--- a/src/Plant/BackEnd/api/v1/marketing_drafts.py
+++ b/src/Plant/BackEnd/api/v1/marketing_drafts.py
@@ -56,6 +56,11 @@ class CreateDraftBatchRequest(BaseModel):
     campaign_id: Optional[str] = None
     customer_id: Optional[str] = None
 
+    # Workflow stage: 'theme' = content-plan/table batch, 'content' = actual post batch, 'direct' = single-step
+    batch_type: str = "direct"
+    # Links a content batch back to the theme batch that it was derived from
+    parent_batch_id: Optional[str] = None
+
     theme: str
     brand_name: str
     brief_summary: Optional[str] = None
@@ -181,6 +186,8 @@ async def create_draft_batch(
 
     batch = materialize_batch_record(DraftBatchRecord(
         batch_id=batch_id,
+        batch_type=body.batch_type,
+        parent_batch_id=body.parent_batch_id,
         agent_id=body.agent_id,
         hired_instance_id=body.hired_instance_id,
         campaign_id=body.campaign_id,
@@ -195,6 +202,143 @@ async def create_draft_batch(
     await store.save_batch(batch)
     await db.commit()
     return CreateDraftBatchResponse(**batch.model_dump())
+
+
+class CreateContentBatchFromThemeRequest(BaseModel):
+    """Request to create a content batch from an approved theme batch.
+
+    The caller specifies what content artifacts to generate. The new batch inherits
+    the hired_instance_id, campaign_id, customer_id, brand_name, and approved theme
+    from the parent theme batch.
+    """
+    youtube_credential_ref: Optional[str] = None
+    youtube_visibility: str = "private"
+    public_release_requested: bool = False
+    requested_artifacts: Optional[List[ArtifactRequest]] = None
+
+
+@router.post("/draft-batches/{batch_id}/create-content-batch", response_model=CreateDraftBatchResponse)
+async def create_content_batch_from_theme(
+    batch_id: str,
+    body: CreateContentBatchFromThemeRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db_session),
+) -> CreateDraftBatchResponse:
+    """Create a content batch from an approved theme batch.
+
+    All posts in the theme batch must be approved. The new content batch is linked
+    to the theme batch via parent_batch_id and is tagged batch_type='content'.
+    """
+    from core.exceptions import PolicyEnforcementError
+
+    store = DatabaseDraftBatchStore(db)
+    theme_batch = await store.get_batch(batch_id)
+    if theme_batch is None:
+        raise PolicyEnforcementError(
+            "Unknown theme batch",
+            reason="unknown_batch_id",
+            details={"batch_id": batch_id},
+        )
+
+    if theme_batch.batch_type not in ("theme", "direct"):
+        raise PolicyEnforcementError(
+            "Only a theme batch can spawn a content batch",
+            reason="invalid_batch_type",
+            details={"batch_id": batch_id, "batch_type": theme_batch.batch_type},
+        )
+
+    unapproved = [p for p in theme_batch.posts if p.review_status != "approved"]
+    if unapproved:
+        raise PolicyEnforcementError(
+            "All theme posts must be approved before creating a content batch",
+            reason="theme_not_fully_approved",
+            details={"unapproved_post_ids": [p.post_id for p in unapproved]},
+        )
+
+    # Use the theme text from approved posts as the content brief
+    approved_theme_text = " | ".join(
+        p.text[:200] for p in theme_batch.posts if p.review_status == "approved"
+    )
+    content_theme = approved_theme_text or theme_batch.theme
+
+    youtube_secret_ref = await resolve_youtube_secret_ref(
+        db,
+        hired_instance_id=theme_batch.hired_instance_id,
+        supplied_ref=body.youtube_credential_ref,
+    )
+    correlation_id = request.headers.get("x-correlation-id") or str(uuid4())
+
+    playbook = _marketing_multichannel_playbook()
+    media_store = get_media_artifact_store()
+    channels: List[ChannelName] = list({p.channel for p in theme_batch.posts})
+
+    result = execute_marketing_multichannel_v1(
+        playbook,
+        SkillExecutionInput(
+            theme=content_theme,
+            brand_name=theme_batch.brand_name,
+            channels=channels,
+            requested_artifacts=body.requested_artifacts,
+        ),
+    )
+
+    content_batch_id = str(uuid4())
+    posts: List[DraftPostRecord] = []
+    for variant in result.output.variants:
+        post_id = str(uuid4())
+        prepared = await _prepare_post_artifacts(
+            batch_id=content_batch_id,
+            post_id=post_id,
+            channel=variant.channel,
+            theme=content_theme,
+            brand_name=theme_batch.brand_name,
+            text=variant.text,
+            requested_artifacts=list(result.output.canonical.requested_artifacts or []),
+            pre_generated_artifacts=[
+                GeneratedArtifactReference.model_validate(artifact)
+                for artifact in (variant.generated_artifacts or [])
+            ],
+            media_store=media_store,
+            correlation_id=correlation_id,
+        )
+        posts.append(
+            DraftPostRecord(
+                post_id=post_id,
+                channel=variant.channel,
+                text=variant.text,
+                hashtags=variant.hashtags,
+                artifact_type=prepared["artifact_type"],
+                artifact_uri=prepared["artifact_uri"],
+                artifact_preview_uri=prepared["artifact_preview_uri"],
+                artifact_mime_type=prepared["artifact_mime_type"],
+                artifact_metadata=prepared["artifact_metadata"],
+                artifact_generation_status=prepared["artifact_generation_status"],
+                artifact_job_id=prepared["artifact_job_id"],
+                generated_artifacts=prepared["generated_artifacts"],
+                credential_ref=youtube_secret_ref if variant.channel == ChannelName.YOUTUBE else None,
+                visibility=body.youtube_visibility if variant.channel == ChannelName.YOUTUBE else "private",
+                public_release_requested=body.public_release_requested if variant.channel == ChannelName.YOUTUBE else False,
+            )
+        )
+
+    content_batch = materialize_batch_record(DraftBatchRecord(
+        batch_id=content_batch_id,
+        batch_type="content",
+        parent_batch_id=batch_id,
+        agent_id=theme_batch.agent_id,
+        hired_instance_id=theme_batch.hired_instance_id,
+        campaign_id=theme_batch.campaign_id,
+        customer_id=theme_batch.customer_id,
+        theme=content_theme,
+        brand_name=theme_batch.brand_name,
+        brief_summary=f"Content batch derived from approved theme batch {batch_id}",
+        created_at=datetime.utcnow(),
+        posts=posts,
+    ))
+
+    await store.save_batch(content_batch)
+    await db.commit()
+    return CreateDraftBatchResponse(**content_batch.model_dump())
 
 
 def _table_preview(theme: str, brand_name: str, channel: ChannelName, prompt: str) -> Dict[str, Any]:

--- a/src/Plant/BackEnd/database/migrations/versions/040_dma_batch_type_workflow.py
+++ b/src/Plant/BackEnd/database/migrations/versions/040_dma_batch_type_workflow.py
@@ -1,0 +1,93 @@
+"""Add batch_type and parent_batch_id to marketing_draft_batches
+
+Revision ID: 040_dma_batch_type_workflow
+Revises: 039_credential_ref_and_secret_manager_ref
+Create Date: 2026-04-15
+
+Enables the two-stage DMA workflow:
+  - batch_type = 'theme'   → content plan/table draft for customer to approve
+  - batch_type = 'content' → actual posts created after theme is approved
+  - batch_type = 'direct'  → legacy single-step batch (default, backward-compatible)
+
+parent_batch_id links a content batch back to the theme batch it was derived from.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+
+revision = "040_dma_batch_type_workflow"
+down_revision = "039_credential_ref_and_secret_manager_ref"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+
+    def column_exists(table_name: str, column_name: str) -> bool:
+        return any(c["name"] == column_name for c in inspector.get_columns(table_name))
+
+    def index_exists(table_name: str, index_name: str) -> bool:
+        return any(i["name"] == index_name for i in inspector.get_indexes(table_name))
+
+    if not column_exists("marketing_draft_batches", "batch_type"):
+        op.add_column(
+            "marketing_draft_batches",
+            sa.Column(
+                "batch_type",
+                sa.String(length=32),
+                nullable=False,
+                server_default="direct",
+            ),
+        )
+
+    if not column_exists("marketing_draft_batches", "parent_batch_id"):
+        op.add_column(
+            "marketing_draft_batches",
+            sa.Column("parent_batch_id", sa.String(), nullable=True),
+        )
+        op.create_foreign_key(
+            "fk_marketing_draft_batches_parent_batch_id",
+            "marketing_draft_batches",
+            "marketing_draft_batches",
+            ["parent_batch_id"],
+            ["batch_id"],
+            ondelete="SET NULL",
+        )
+
+    if not index_exists("marketing_draft_batches", "ix_marketing_draft_batches_batch_type"):
+        op.create_index(
+            "ix_marketing_draft_batches_batch_type",
+            "marketing_draft_batches",
+            ["batch_type"],
+        )
+
+    if not index_exists("marketing_draft_batches", "ix_marketing_draft_batches_parent_batch_id"):
+        op.create_index(
+            "ix_marketing_draft_batches_parent_batch_id",
+            "marketing_draft_batches",
+            ["parent_batch_id"],
+        )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_marketing_draft_batches_parent_batch_id",
+        table_name="marketing_draft_batches",
+    )
+    op.drop_index(
+        "ix_marketing_draft_batches_batch_type",
+        table_name="marketing_draft_batches",
+    )
+    op.drop_constraint(
+        "fk_marketing_draft_batches_parent_batch_id",
+        "marketing_draft_batches",
+        type_="foreignkey",
+    )
+    op.drop_column("marketing_draft_batches", "parent_batch_id")
+    op.drop_column("marketing_draft_batches", "batch_type")

--- a/src/Plant/BackEnd/models/marketing_draft.py
+++ b/src/Plant/BackEnd/models/marketing_draft.py
@@ -13,6 +13,13 @@ class MarketingDraftBatchModel(Base):
     __tablename__ = "marketing_draft_batches"
 
     batch_id = Column(String, primary_key=True, nullable=False)
+    batch_type = Column(String(32), nullable=False, default="direct", index=True)
+    parent_batch_id = Column(
+        String,
+        ForeignKey("marketing_draft_batches.batch_id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     agent_id = Column(String, nullable=False, index=True)
     hired_instance_id = Column(
         String,
@@ -36,6 +43,12 @@ class MarketingDraftBatchModel(Base):
         back_populates="batch",
         cascade="all, delete-orphan",
         order_by="MarketingDraftPostModel.created_at",
+    )
+    child_batches = relationship(
+        "MarketingDraftBatchModel",
+        foreign_keys="MarketingDraftBatchModel.parent_batch_id",
+        primaryjoin="MarketingDraftBatchModel.batch_id == foreign(MarketingDraftBatchModel.parent_batch_id)",
+        lazy="select",
     )
 
     __table_args__ = (

--- a/src/Plant/BackEnd/requirements.txt
+++ b/src/Plant/BackEnd/requirements.txt
@@ -42,6 +42,7 @@ python-dotenv==1.0.0
 httpx==0.26.0
 openai==2.26.0
 google-auth[requests]==2.37.0
+google-cloud-secret-manager==2.26.0
 pyyaml==6.0.1
 tenacity==8.2.3  # Retry logic with exponential backoff
 

--- a/src/Plant/BackEnd/services/draft_batches.py
+++ b/src/Plant/BackEnd/services/draft_batches.py
@@ -60,6 +60,8 @@ class DraftPostRecord(BaseModel):
 
 class DraftBatchRecord(BaseModel):
     batch_id: str = Field(..., min_length=1)
+    batch_type: str = "direct"  # theme | content | direct
+    parent_batch_id: Optional[str] = None
     agent_id: str = Field(..., min_length=1)
     hired_instance_id: Optional[str] = None
     campaign_id: Optional[str] = None
@@ -83,6 +85,8 @@ class DatabaseDraftBatchStore:
     async def save_batch(self, batch: DraftBatchRecord) -> None:
         batch_model = MarketingDraftBatchModel(
             batch_id=batch.batch_id,
+            batch_type=batch.batch_type,
+            parent_batch_id=batch.parent_batch_id,
             agent_id=batch.agent_id,
             hired_instance_id=batch.hired_instance_id,
             campaign_id=batch.campaign_id,
@@ -233,6 +237,8 @@ class DatabaseDraftBatchStore:
     def _batch_model_to_record(self, model: MarketingDraftBatchModel) -> DraftBatchRecord:
         return materialize_batch_record(DraftBatchRecord(
             batch_id=model.batch_id,
+            batch_type=getattr(model, 'batch_type', 'direct') or 'direct',
+            parent_batch_id=getattr(model, 'parent_batch_id', None),
             agent_id=model.agent_id,
             hired_instance_id=model.hired_instance_id,
             campaign_id=model.campaign_id,

--- a/src/Plant/BackEnd/tests/bdd/features/dma_staged_workflow.feature
+++ b/src/Plant/BackEnd/tests/bdd/features/dma_staged_workflow.feature
@@ -1,0 +1,52 @@
+Feature: DMA Staged Workflow — Theme to Content to Publish
+  As a customer using the Digital Marketing Agent
+  I want to review an AI-generated content theme before any content is produced
+  So that I can ensure brand alignment before approving execution
+
+  # ── Scenario 1: Full happy path ─────────────────────────────────────────────
+
+  @bdd @dma
+  Scenario: Customer approves theme batch and triggers content creation
+    Given a customer "CUST-BDD-001" has hired DMA agent "AGT-MKT-DMA-001"
+    When the customer submits a theme batch for "Care Clinic" on channel "youtube"
+    Then the batch is created with status "pending_review"
+    And all posts are in state "pending_review"
+    When the customer approves all posts in the theme batch
+    Then each post has review_status "approved"
+    When the customer triggers content batch creation from the approved theme
+    Then a new content batch is created linked to the theme batch
+    And the content batch has batch_type "content"
+
+  # ── Scenario 2: Approval gate blocks early content creation ─────────────────
+
+  @bdd @dma
+  Scenario: Content creation is blocked until all theme posts are approved
+    Given a customer "CUST-BDD-002" has hired DMA agent "AGT-MKT-DMA-001"
+    When the customer submits a theme batch for "Brand X" on channel "youtube"
+    And the customer has NOT approved all posts
+    When the customer attempts to create a content batch from the unapproved theme
+    Then the request is rejected with status 403
+    And the rejection reason is "theme_not_fully_approved"
+
+  # ── Scenario 3: Secret adapter wiring ───────────────────────────────────────
+
+  @bdd @dma
+  Scenario: Local secret adapter rejects GCP-format credential refs
+    Given the secret backend is configured as "local"
+    When a GCP-format credential ref is read
+    Then the adapter raises a ValueError containing "Unsupported local secret ref"
+
+  @bdd @dma
+  Scenario: GCP secret adapter is selected when SECRET_MANAGER_BACKEND is gcp
+    Given the secret backend is configured as "gcp"
+    And GCP_PROJECT_ID is set to "waooaw-oauth"
+    Then the factory returns a GcpSecretManagerAdapter
+
+  # ── Scenario 4: Rejected posts are never published ───────────────────────────
+
+  @bdd @dma
+  Scenario: Rejected content post cannot be published
+    Given a customer "CUST-BDD-003" has a content post
+    When the customer rejects the post with reason "wrong tone"
+    And the customer attempts to publish the rejected post
+    Then the publish request is rejected with status 403

--- a/src/Plant/BackEnd/tests/bdd/test_dma_staged_workflow.py
+++ b/src/Plant/BackEnd/tests/bdd/test_dma_staged_workflow.py
@@ -1,0 +1,296 @@
+"""BDD step definitions for DMA staged workflow feature.
+
+Captures customer-expected behaviour from the April 2026 production issues:
+  - ValueError: Unsupported local secret ref (wrong adapter)
+  - Missing batch_type / parent_batch_id causing workflow to dead-end
+  - Approval gate not enforced, letting content be created from unapproved themes
+
+Run with:
+  pytest tests/bdd/test_dma_staged_workflow.py -v -k "dma"
+"""
+from __future__ import annotations
+
+import importlib
+import os
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pytest_bdd import given, when, then, scenarios, parsers
+
+scenarios("features/dma_staged_workflow.feature")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared context object
+# ─────────────────────────────────────────────────────────────────────────────
+
+class DmaContext:
+    def __init__(self) -> None:
+        self.customer_id: str = ""
+        self.agent_id: str = ""
+        self.theme_batch: Dict[str, Any] = {}
+        self.content_batch: Dict[str, Any] = {}
+        self.last_response: Any = None
+        self.secret_backend: str = "local"
+        self.adapter: Any = None
+        self.adapter_error: Exception | None = None
+        self.rejected_post_id: str = ""
+        self.publish_response: Any = None
+
+
+@pytest.fixture
+def dma_ctx():
+    return DmaContext()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Scenarios 1 & 2 — full staged workflow (uses test_client fixture)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@given(parsers.parse('a customer "{customer_id}" has hired DMA agent "{agent_id}"'))
+def given_customer_hired_agent(dma_ctx, customer_id, agent_id):
+    dma_ctx.customer_id = customer_id
+    dma_ctx.agent_id = agent_id
+
+
+@when(parsers.parse('the customer submits a theme batch for "{brand_name}" on channel "{channel}"'))
+def when_customer_submits_theme_batch(dma_ctx, test_client, in_memory_marketing_draft_store, brand_name, channel):
+    resp = test_client.post(
+        "/api/v1/marketing/draft-batches",
+        json={
+            "agent_id": dma_ctx.agent_id,
+            "hired_instance_id": f"HIRED-BDD-{dma_ctx.customer_id}",
+            "customer_id": dma_ctx.customer_id,
+            "theme": f"Weekly content plan for {brand_name}",
+            "brand_name": brand_name,
+            "batch_type": "theme",
+            "channels": [channel],
+        },
+    )
+    dma_ctx.theme_batch = resp.json()
+    dma_ctx.last_response = resp
+
+
+@then(parsers.parse('the batch is created with status "{status}"'))
+def then_batch_created_with_status(dma_ctx, status):
+    assert dma_ctx.last_response.status_code == 200, (
+        f"Expected 200, got {dma_ctx.last_response.status_code}"
+    )
+    assert dma_ctx.theme_batch["status"] == status, (
+        f"Expected status={status!r}, got {dma_ctx.theme_batch['status']!r}"
+    )
+
+
+@then('all posts are in state "pending_review"')
+def then_all_posts_pending(dma_ctx):
+    for post in dma_ctx.theme_batch.get("posts", []):
+        assert post["review_status"] == "pending_review", (
+            f"Post {post['post_id']} not pending: {post['review_status']}"
+        )
+
+
+@when("the customer approves all posts in the theme batch")
+def when_approve_all_posts(dma_ctx, test_client):
+    for i, post in enumerate(dma_ctx.theme_batch.get("posts", [])):
+        resp = test_client.post(
+            f"/api/v1/marketing/draft-posts/{post['post_id']}/approve",
+            json={"approval_id": f"APR-BDD-{i:03d}"},
+        )
+        assert resp.status_code == 200, f"Approve failed: {resp.json()}"
+
+
+@then(parsers.parse('each post has review_status "{review_status}"'))
+def then_each_post_has_review_status(dma_ctx, test_client, review_status):
+    batch_id = dma_ctx.theme_batch["batch_id"]
+    resp = test_client.get(
+        "/api/v1/marketing/draft-batches",
+        params={"customer_id": dma_ctx.customer_id},
+    )
+    assert resp.status_code == 200
+    batches = resp.json()
+    batch = next((b for b in batches if b["batch_id"] == batch_id), None)
+    assert batch is not None, f"Batch {batch_id} not found in list response"
+    for post in batch.get("posts", []):
+        assert post["review_status"] == review_status, (
+            f"Post {post['post_id']} has review_status={post['review_status']!r}, expected {review_status!r}"
+        )
+
+
+@when("the customer triggers content batch creation from the approved theme")
+def when_customer_triggers_content_batch(dma_ctx, test_client):
+    batch_id = dma_ctx.theme_batch["batch_id"]
+    resp = test_client.post(
+        f"/api/v1/marketing/draft-batches/{batch_id}/create-content-batch",
+        json={},
+    )
+    dma_ctx.content_batch = resp.json() if resp.status_code == 200 else {}
+    dma_ctx.last_response = resp
+
+
+@then("a new content batch is created linked to the theme batch")
+def then_content_batch_created(dma_ctx):
+    assert dma_ctx.last_response.status_code == 200, (
+        f"Expected 200, got {dma_ctx.last_response.status_code}: {dma_ctx.last_response.json()}"
+    )
+    assert dma_ctx.content_batch.get("parent_batch_id") == dma_ctx.theme_batch["batch_id"], (
+        f"parent_batch_id mismatch: {dma_ctx.content_batch.get('parent_batch_id')!r}"
+    )
+
+
+@then(parsers.parse('the content batch has batch_type "{batch_type}"'))
+def then_content_batch_type(dma_ctx, batch_type):
+    assert dma_ctx.content_batch.get("batch_type") == batch_type, (
+        f"Expected batch_type={batch_type!r}, got {dma_ctx.content_batch.get('batch_type')!r}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Scenario 2 — approval gate
+# ─────────────────────────────────────────────────────────────────────────────
+
+@when("the customer has NOT approved all posts")
+def when_customer_has_not_approved(dma_ctx):
+    # No action needed — posts start as pending_review which is the unapproved state
+    pass
+
+
+@when("the customer attempts to create a content batch from the unapproved theme")
+def when_attempt_content_batch_unapproved(dma_ctx, test_client):
+    batch_id = dma_ctx.theme_batch["batch_id"]
+    resp = test_client.post(
+        f"/api/v1/marketing/draft-batches/{batch_id}/create-content-batch",
+        json={},
+    )
+    dma_ctx.last_response = resp
+
+
+@then(parsers.parse("the request is rejected with status {status_code:d}"))
+def then_rejected_with_status(dma_ctx, status_code):
+    assert dma_ctx.last_response.status_code == status_code, (
+        f"Expected {status_code}, got {dma_ctx.last_response.status_code}: "
+        f"{dma_ctx.last_response.json()}"
+    )
+
+
+@then(parsers.parse('the rejection reason is "{reason}"'))
+def then_rejection_reason(dma_ctx, reason):
+    body = dma_ctx.last_response.json()
+    # Reason can be in 'reason' field or encoded in 'detail'
+    actual_reason = body.get("reason", "") or body.get("detail", "")
+    assert reason in actual_reason or reason.replace("_", " ") in actual_reason.lower(), (
+        f"Expected reason={reason!r} in response, got: {body}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Scenario 3 — secret adapter wiring
+# ─────────────────────────────────────────────────────────────────────────────
+
+@given(parsers.parse('the secret backend is configured as "{backend}"'))
+def given_secret_backend(dma_ctx, monkeypatch, backend):
+    dma_ctx.secret_backend = backend
+    monkeypatch.setenv("SECRET_MANAGER_BACKEND", backend)
+    if backend == "local":
+        monkeypatch.delenv("GCP_PROJECT_ID", raising=False)
+
+
+@given(parsers.parse('GCP_PROJECT_ID is set to "{project_id}"'))
+def given_gcp_project_id(monkeypatch, project_id):
+    monkeypatch.setenv("GCP_PROJECT_ID", project_id)
+
+
+@when("a GCP-format credential ref is read")
+def when_gcp_ref_read(dma_ctx):
+    import asyncio
+    from services.secret_manager_adapter import LocalSecretManagerAdapter
+
+    adapter = LocalSecretManagerAdapter()
+    gcp_ref = "projects/waooaw-oauth/secrets/hired-1-youtube/versions/latest"
+    try:
+        asyncio.run(adapter.read_secret(gcp_ref))
+        dma_ctx.adapter_error = None
+    except ValueError as exc:
+        dma_ctx.adapter_error = exc
+
+
+@then(parsers.parse('the adapter raises a ValueError containing "{message}"'))
+def then_raises_value_error(dma_ctx, message):
+    assert dma_ctx.adapter_error is not None, (
+        "Expected a ValueError to be raised, but no error occurred"
+    )
+    assert message in str(dma_ctx.adapter_error), (
+        f"Expected {message!r} in error message, got: {dma_ctx.adapter_error!r}"
+    )
+
+
+@then("the factory returns a GcpSecretManagerAdapter")
+def then_factory_returns_gcp_adapter(monkeypatch):
+    fake_sm = MagicMock()
+    fake_sm.SecretManagerServiceClient.return_value = MagicMock()
+
+    with patch.dict("sys.modules", {
+        "google.cloud.secretmanager": fake_sm,
+        "google.cloud": MagicMock(secretmanager=fake_sm),
+        "google": MagicMock(),
+    }):
+        import services.secret_manager_adapter as mod
+        importlib.reload(mod)
+        adapter = mod.get_secret_manager_adapter()
+        assert isinstance(adapter, mod.GcpSecretManagerAdapter)
+
+    importlib.reload(mod)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Scenario 4 — rejected post cannot be published
+# ─────────────────────────────────────────────────────────────────────────────
+
+@given(parsers.parse('a customer "{customer_id}" has a content post'))
+def given_customer_has_content_post(dma_ctx, test_client, in_memory_marketing_draft_store, customer_id):
+    dma_ctx.customer_id = customer_id
+    dma_ctx.agent_id = "AGT-MKT-DMA-001"
+    resp = test_client.post(
+        "/api/v1/marketing/draft-batches",
+        json={
+            "agent_id": dma_ctx.agent_id,
+            "hired_instance_id": "HIRED-BDD-REJECT",
+            "customer_id": customer_id,
+            "theme": "Test content",
+            "brand_name": "Test Brand",
+            "channels": ["youtube"],
+        },
+    )
+    assert resp.status_code == 200
+    batch = resp.json()
+    dma_ctx.rejected_post_id = batch["posts"][0]["post_id"]
+
+
+@when(parsers.parse('the customer rejects the post with reason "{reason}"'))
+def when_customer_rejects_post(dma_ctx, test_client, reason):
+    resp = test_client.post(
+        f"/api/v1/marketing/draft-posts/{dma_ctx.rejected_post_id}/reject",
+        json={"reason": reason},
+    )
+    assert resp.status_code == 200, f"Reject failed: {resp.json()}"
+
+
+@when("the customer attempts to publish the rejected post")
+def when_customer_publishes_rejected(dma_ctx, test_client):
+    resp = test_client.post(
+        f"/api/v1/marketing/draft-posts/{dma_ctx.rejected_post_id}/execute",
+        json={
+            "agent_id": dma_ctx.agent_id,
+            "approval_id": "APR-FAKE-999",
+            "intent_action": "publish",
+        },
+    )
+    dma_ctx.publish_response = resp
+
+
+@then(parsers.parse("the publish request is rejected with status {status_code:d}"))
+def then_publish_rejected(dma_ctx, status_code):
+    assert dma_ctx.publish_response.status_code == status_code, (
+        f"Expected {status_code}, got {dma_ctx.publish_response.status_code}: "
+        f"{dma_ctx.publish_response.json()}"
+    )

--- a/src/Plant/BackEnd/tests/unit/test_dma_dependency_bootstrap.py
+++ b/src/Plant/BackEnd/tests/unit/test_dma_dependency_bootstrap.py
@@ -1,0 +1,160 @@
+"""Dependency-bootstrap tests for the DMA publish path.
+
+These tests would have caught the two production failures in April 2026:
+  1. ImportError: google-cloud-secret-manager not installed
+  2. ValueError: Unsupported local secret ref (wrong adapter selected for GCP path)
+
+All tests are unit-level — no DB, no real GCP calls.
+"""
+from __future__ import annotations
+
+import os
+import importlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1. Adapter factory wiring
+# ---------------------------------------------------------------------------
+
+def test_factory_returns_local_adapter_when_env_unset(monkeypatch):
+    """Default (no SECRET_MANAGER_BACKEND) must yield LocalSecretManagerAdapter."""
+    monkeypatch.delenv("SECRET_MANAGER_BACKEND", raising=False)
+    from services.secret_manager_adapter import get_secret_manager_adapter, LocalSecretManagerAdapter
+
+    adapter = get_secret_manager_adapter()
+    assert isinstance(adapter, LocalSecretManagerAdapter)
+
+
+def test_factory_returns_local_adapter_when_set_to_local(monkeypatch):
+    monkeypatch.setenv("SECRET_MANAGER_BACKEND", "local")
+    from services.secret_manager_adapter import get_secret_manager_adapter, LocalSecretManagerAdapter
+
+    adapter = get_secret_manager_adapter()
+    assert isinstance(adapter, LocalSecretManagerAdapter)
+
+
+def test_factory_returns_gcp_adapter_when_set_to_gcp(monkeypatch):
+    """SECRET_MANAGER_BACKEND=gcp must return GcpSecretManagerAdapter.
+
+    Simulates the Cloud Run environment: google-cloud-secret-manager IS installed
+    (it's in requirements.txt now) and GCP_PROJECT_ID is provided.
+    """
+    monkeypatch.setenv("SECRET_MANAGER_BACKEND", "gcp")
+    monkeypatch.setenv("GCP_PROJECT_ID", "waooaw-oauth")
+
+    fake_secretmanager = MagicMock()
+    fake_secretmanager.SecretManagerServiceClient.return_value = MagicMock()
+
+    fake_google_cloud = MagicMock()
+    fake_google_cloud.secretmanager = fake_secretmanager
+
+    with patch.dict("sys.modules", {
+        "google": fake_google_cloud,
+        "google.cloud": fake_google_cloud,
+        "google.cloud.secretmanager": fake_secretmanager,
+    }):
+        # Force reimport so class __init__ re-runs under patched sys.modules
+        import services.secret_manager_adapter as mod
+        importlib.reload(mod)
+        adapter = mod.get_secret_manager_adapter()
+        assert isinstance(adapter, mod.GcpSecretManagerAdapter)
+
+    # Restore module to original state
+    importlib.reload(mod)
+
+
+def test_factory_raises_when_gcp_project_missing(monkeypatch):
+    """GCP backend without a project ID must fail fast at startup, not at first publish."""
+    monkeypatch.setenv("SECRET_MANAGER_BACKEND", "gcp")
+    monkeypatch.delenv("GCP_PROJECT_ID", raising=False)
+    monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+
+    from services import secret_manager_adapter as mod
+    importlib.reload(mod)
+
+    with pytest.raises(RuntimeError, match="GCP_PROJECT_ID"):
+        # We need to patch the GCP import so it doesn't fail on missing package
+        fake_sm = MagicMock()
+        fake_sm.SecretManagerServiceClient.return_value = MagicMock()
+        with patch.dict("sys.modules", {
+            "google.cloud.secretmanager": fake_sm,
+            "google.cloud": MagicMock(secretmanager=fake_sm),
+            "google": MagicMock(),
+        }):
+            importlib.reload(mod)
+            mod.get_secret_manager_adapter()
+
+    importlib.reload(mod)
+
+
+# ---------------------------------------------------------------------------
+# 2. LocalSecretManagerAdapter rejects GCP-format paths
+#    (exact error that appeared in logs before PR-1063 fix)
+# ---------------------------------------------------------------------------
+
+def test_local_adapter_raises_on_gcp_format_secret_ref():
+    """LocalSecretManagerAdapter must raise ValueError for GCP-format refs.
+
+    If SECRET_MANAGER_BACKEND is accidentally left as 'local' in Cloud Run
+    while credential_refs are GCP paths, every publish attempt will blow up
+    here. This test locks in that contract so the error is obvious pre-deploy.
+    """
+    from services.secret_manager_adapter import LocalSecretManagerAdapter
+
+    adapter = LocalSecretManagerAdapter()
+    gcp_ref = "projects/waooaw-oauth/secrets/hired-1-youtube/versions/latest"
+
+    with pytest.raises(ValueError, match="Unsupported local secret ref"):
+        import asyncio
+        asyncio.run(adapter.read_secret(gcp_ref))
+
+
+def test_local_adapter_roundtrips_local_format_ref():
+    """LocalSecretManagerAdapter correctly reads back what it wrote."""
+    from services.secret_manager_adapter import LocalSecretManagerAdapter
+
+    adapter = LocalSecretManagerAdapter()
+    adapter._store.clear()  # isolate from other tests
+
+    import asyncio
+    ref = asyncio.run(adapter.write_secret("test-secret-id", {"access_token": "tok"}))
+    assert ref.startswith("local://secrets/")
+
+    data = asyncio.run(adapter.read_secret(ref))
+    assert data == {"access_token": "tok"}
+
+
+# ---------------------------------------------------------------------------
+# 3. Package import — would have caught missing google-cloud-secret-manager
+# ---------------------------------------------------------------------------
+
+def test_gcp_adapter_class_is_importable():
+    """GcpSecretManagerAdapter must be importable without triggering import of
+    google.cloud.secretmanager at module load time (import is deferred to __init__).
+
+    This test verifies the lazy-import pattern is in place.
+    """
+    from services.secret_manager_adapter import GcpSecretManagerAdapter
+
+    # The class should exist as a name in the module
+    assert GcpSecretManagerAdapter is not None
+
+
+def test_gcp_adapter_init_fails_gracefully_when_package_missing(monkeypatch):
+    """If google-cloud-secret-manager is NOT installed, GcpSecretManagerAdapter.__init__
+    raises ImportError immediately (not silently at first I/O operation).
+
+    This test simulates the exact production failure mode from April 2026 where
+    the package was missing and every YouTube publish returned ImportError.
+    """
+    # Temporarily hide the package from sys.modules
+    with patch.dict("sys.modules", {
+        "google.cloud.secretmanager": None,  # None means "not importable"
+    }):
+        from services.secret_manager_adapter import GcpSecretManagerAdapter
+        with pytest.raises((ImportError, ModuleNotFoundError)):
+            GcpSecretManagerAdapter(project_id="waooaw-oauth")
+

--- a/src/Plant/BackEnd/tests/unit/test_dma_full_workflow.py
+++ b/src/Plant/BackEnd/tests/unit/test_dma_full_workflow.py
@@ -426,3 +426,78 @@ def test_short_credential_ref_is_resolved_to_gcp_path_at_batch_creation(
     assert create.status_code == 200
     post = create.json()["posts"][0]
     assert post["credential_ref"] == "projects/waooaw-oauth/secrets/hired-wf-001-youtube/versions/latest"
+
+
+# ---------------------------------------------------------------------------
+# Stage 9: batch_type field preserved end-to-end
+# ---------------------------------------------------------------------------
+
+def test_theme_batch_carries_batch_type_theme(test_client, in_memory_marketing_draft_store):
+    """A batch created with batch_type='theme' is stored and returned with that type."""
+    resp = test_client.post(
+        "/api/v1/marketing/draft-batches",
+        json={**_THEME_PAYLOAD, "batch_type": "theme"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["batch_type"] == "theme"
+
+    batch_id = resp.json()["batch_id"]
+    get_resp = test_client.get(f"/api/v1/marketing/draft-batches/{batch_id}")
+    assert get_resp.status_code == 200
+    assert get_resp.json()["batch_type"] == "theme"
+
+
+def test_create_content_batch_from_approved_theme_batch(
+    test_client, in_memory_marketing_draft_store, monkeypatch
+):
+    """POST /draft-batches/{id}/create-content-batch succeeds when all theme posts are approved.
+    The resulting batch has batch_type='content' and parent_batch_id pointing to the theme batch.
+    """
+    # Step 1: create theme batch
+    create_theme = test_client.post(
+        "/api/v1/marketing/draft-batches",
+        json={**_THEME_PAYLOAD, "batch_type": "theme"},
+    )
+    assert create_theme.status_code == 200
+    theme_batch_id = create_theme.json()["batch_id"]
+    theme_post_id = create_theme.json()["posts"][0]["post_id"]
+
+    # Step 2: approve all theme posts
+    test_client.post(
+        f"/api/v1/marketing/draft-posts/{theme_post_id}/approve",
+        json={"approval_id": "APR-THEME-STAGE9"},
+    )
+
+    # Step 3: create content batch from approved theme
+    content_resp = test_client.post(
+        f"/api/v1/marketing/draft-batches/{theme_batch_id}/create-content-batch",
+        json={
+            "youtube_credential_ref": "projects/waooaw-oauth/secrets/hired-1-youtube/versions/latest",
+        },
+    )
+    assert content_resp.status_code == 200
+    content_data = content_resp.json()
+
+    assert content_data["batch_type"] == "content"
+    assert content_data["parent_batch_id"] == theme_batch_id
+    assert len(content_data["posts"]) > 0
+    assert all(p["review_status"] == "pending_review" for p in content_data["posts"])
+
+
+def test_create_content_batch_blocked_when_theme_not_fully_approved(
+    test_client, in_memory_marketing_draft_store
+):
+    """Content batch cannot be created if any theme post is still pending."""
+    create_theme = test_client.post(
+        "/api/v1/marketing/draft-batches",
+        json={**_THEME_PAYLOAD, "batch_type": "theme"},
+    )
+    theme_batch_id = create_theme.json()["batch_id"]
+
+    # Do NOT approve — attempt content creation immediately
+    content_resp = test_client.post(
+        f"/api/v1/marketing/draft-batches/{theme_batch_id}/create-content-batch",
+        json={},
+    )
+    assert content_resp.status_code == 403
+    assert content_resp.json()["reason"] == "theme_not_fully_approved"

--- a/src/Plant/BackEnd/tests/unit/test_dma_schema_integrity.py
+++ b/src/Plant/BackEnd/tests/unit/test_dma_schema_integrity.py
@@ -1,0 +1,247 @@
+"""Schema integrity tests for DMA models.
+
+These tests verify that the SQLAlchemy ORM columns we rely on actually exist
+on the in-memory models. They would have caught missing batch_type /
+parent_batch_id columns before any DB migration or API call was attempted.
+
+All tests are unit-level — no real Postgres required.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# MarketingDraftBatchModel column presence
+# ---------------------------------------------------------------------------
+
+def test_batch_model_has_required_columns():
+    """All columns the DMA workflow depends on must be present on the batch model."""
+    from models.marketing_draft import MarketingDraftBatchModel
+
+    mapper = MarketingDraftBatchModel.__table__.columns
+    required = {
+        "batch_id",
+        "batch_type",
+        "parent_batch_id",
+        "agent_id",
+        "customer_id",
+        "theme",
+        "brand_name",
+        "workflow_state",
+        "status",
+        "created_at",
+    }
+    missing = required - set(mapper.keys())
+    assert not missing, f"Missing columns on MarketingDraftBatchModel: {missing}"
+
+
+def test_batch_type_has_default_direct():
+    """batch_type server default must be 'direct' so existing rows without the column stay valid."""
+    from models.marketing_draft import MarketingDraftBatchModel
+
+    col = MarketingDraftBatchModel.__table__.columns["batch_type"]
+    # SQLAlchemy stores Python-side default on column.default.arg
+    assert col.default is not None or col.server_default is not None, (
+        "batch_type must have a default value"
+    )
+
+
+def test_parent_batch_id_is_nullable():
+    """parent_batch_id must be nullable — top-level batches have no parent."""
+    from models.marketing_draft import MarketingDraftBatchModel
+
+    col = MarketingDraftBatchModel.__table__.columns["parent_batch_id"]
+    assert col.nullable is True, "parent_batch_id must be nullable"
+
+
+def test_parent_batch_id_has_foreign_key():
+    """parent_batch_id must reference marketing_draft_batches.batch_id (self-join)."""
+    from models.marketing_draft import MarketingDraftBatchModel
+
+    col = MarketingDraftBatchModel.__table__.columns["parent_batch_id"]
+    fk_targets = [fk.target_fullname for fk in col.foreign_keys]
+    assert any("marketing_draft_batches" in t for t in fk_targets), (
+        f"parent_batch_id has no FK to marketing_draft_batches. Got: {fk_targets}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# MarketingDraftPostModel column presence
+# ---------------------------------------------------------------------------
+
+def test_post_model_has_required_columns():
+    """All columns the DMA publish path depends on must be present on the post model."""
+    from models.marketing_draft import MarketingDraftPostModel
+
+    mapper = MarketingDraftPostModel.__table__.columns
+    required = {
+        "post_id",
+        "batch_id",
+        "channel",
+        "text",
+        "credential_ref",
+        "artifact_type",
+        "artifact_mime_type",
+        "review_status",
+        "execution_status",
+        "created_at",
+        "updated_at",
+    }
+    missing = required - set(mapper.keys())
+    assert not missing, f"Missing columns on MarketingDraftPostModel: {missing}"
+
+
+def test_credential_ref_is_nullable():
+    """credential_ref is nullable — only YouTube posts need it."""
+    from models.marketing_draft import MarketingDraftPostModel
+
+    col = MarketingDraftPostModel.__table__.columns["credential_ref"]
+    assert col.nullable is True
+
+
+def test_review_status_has_default():
+    """review_status must default to 'pending_review' so new posts don't start approved."""
+    from models.marketing_draft import MarketingDraftPostModel
+
+    col = MarketingDraftPostModel.__table__.columns["review_status"]
+    assert col.default is not None or col.server_default is not None, (
+        "review_status must have a default"
+    )
+
+
+# ---------------------------------------------------------------------------
+# DraftBatchRecord / DraftPostRecord Pydantic models
+# ---------------------------------------------------------------------------
+
+def test_draft_batch_record_roundtrips_batch_type():
+    """DraftBatchRecord must accept and expose batch_type."""
+    from services.draft_batches import DraftBatchRecord, DraftPostRecord
+    from datetime import datetime, timezone
+
+    rec = DraftBatchRecord(
+        batch_id="B-1",
+        agent_id="AGT-1",
+        customer_id="CUST-1",
+        theme="test theme",
+        brand_name="Brand",
+        workflow_state="draft_ready_for_review",
+        status="pending_review",
+        created_at=datetime.now(tz=timezone.utc),
+        posts=[],
+        batch_type="theme",
+        parent_batch_id=None,
+    )
+    assert rec.batch_type == "theme"
+    assert rec.parent_batch_id is None
+
+
+def test_draft_batch_record_defaults_batch_type_to_direct():
+    """Omitting batch_type must default to 'direct' for backward compatibility."""
+    from services.draft_batches import DraftBatchRecord
+    from datetime import datetime, timezone
+
+    rec = DraftBatchRecord(
+        batch_id="B-2",
+        agent_id="AGT-1",
+        customer_id="CUST-1",
+        theme="test theme",
+        brand_name="Brand",
+        workflow_state="draft_ready_for_review",
+        status="pending_review",
+        created_at=datetime.now(tz=timezone.utc),
+        posts=[],
+    )
+    assert rec.batch_type == "direct"
+
+
+def test_draft_batch_record_accepts_parent_batch_id():
+    """Content batch must carry parent_batch_id pointing to the theme batch."""
+    from services.draft_batches import DraftBatchRecord
+    from datetime import datetime, timezone
+
+    rec = DraftBatchRecord(
+        batch_id="B-CONTENT-1",
+        agent_id="AGT-1",
+        customer_id="CUST-1",
+        theme="Tip #1",
+        brand_name="Brand",
+        workflow_state="draft_ready_for_review",
+        status="pending_review",
+        created_at=datetime.now(tz=timezone.utc),
+        posts=[],
+        batch_type="content",
+        parent_batch_id="B-THEME-1",
+    )
+    assert rec.batch_type == "content"
+    assert rec.parent_batch_id == "B-THEME-1"
+
+
+# ---------------------------------------------------------------------------
+# API request model — create-content-batch endpoint guard
+# ---------------------------------------------------------------------------
+
+def test_create_content_batch_blocked_when_no_posts_approved(
+    test_client, in_memory_marketing_draft_store
+):
+    """create-content-batch returns 403 when theme batch has no approved posts."""
+    create = test_client.post(
+        "/api/v1/marketing/draft-batches",
+        json={
+            "agent_id": "AGT-MKT-HEALTH-001",
+            "hired_instance_id": "HIRED-1",
+            "customer_id": "CUST-SCHEMA-1",
+            "theme": "Test theme",
+            "brand_name": "Brand",
+            "batch_type": "theme",
+            "channels": ["youtube"],
+        },
+    )
+    assert create.status_code == 200
+    batch_id = create.json()["batch_id"]
+
+    # All posts are still pending_review → must be blocked
+    resp = test_client.post(
+        f"/api/v1/marketing/draft-batches/{batch_id}/create-content-batch",
+        json={},
+    )
+    assert resp.status_code == 403
+    detail = resp.json().get("detail", "").lower()
+    assert "approved" in detail, f"Expected approval guard message, got: {detail!r}"
+
+
+def test_create_content_batch_succeeds_when_all_posts_approved(
+    test_client, in_memory_marketing_draft_store
+):
+    """create-content-batch returns 200 when every theme post is approved."""
+    create = test_client.post(
+        "/api/v1/marketing/draft-batches",
+        json={
+            "agent_id": "AGT-MKT-HEALTH-001",
+            "hired_instance_id": "HIRED-1",
+            "customer_id": "CUST-SCHEMA-2",
+            "theme": "Test theme",
+            "brand_name": "Brand",
+            "batch_type": "theme",
+            "channels": ["youtube"],
+        },
+    )
+    assert create.status_code == 200
+    batch = create.json()
+    batch_id = batch["batch_id"]
+    post_id = batch["posts"][0]["post_id"]
+
+    # Approve the single post
+    test_client.post(
+        f"/api/v1/marketing/draft-posts/{post_id}/approve",
+        json={"approval_id": "APR-SCHEMA-001"},
+    )
+
+    resp = test_client.post(
+        f"/api/v1/marketing/draft-batches/{batch_id}/create-content-batch",
+        json={},
+    )
+    assert resp.status_code == 200
+    content = resp.json()
+    assert content["batch_type"] == "content"
+    assert content["parent_batch_id"] == batch_id


### PR DESCRIPTION
## What was wrong

Two separate root causes were found via GCP Cloud Run logs for revision `waooaw-plant-backend-demo-00211-gqs` (deployed PR-1064):

| Root cause | Error | Impact |
|---|---|---|
| `google-cloud-secret-manager` missing from Plant `requirements.txt` | `ImportError: cannot import name 'secretmanager' from 'google.cloud'` | YouTube publish fails every time after PR-1064 set `SECRET_MANAGER_BACKEND=gcp` |
| No `batch_type` / `parent_batch_id` in DB | No schema for theme vs content stages | Workflow Theme→Approve→Content→Approve→Publish was impossible to model or execute |

---

## Changes

### Plant Backend
- **`requirements.txt`**: add `google-cloud-secret-manager==2.26.0` (matches CP Backend version)
- **`models/marketing_draft.py`**: `batch_type` column (`theme` | `content` | `direct`, default `direct`) + `parent_batch_id` self-referential FK with `child_batches` relationship
- **`services/draft_batches.py`**: `DraftBatchRecord` carries `batch_type` + `parent_batch_id`; `save_batch` and `_batch_model_to_record` roundtrip both fields
- **`api/v1/marketing_drafts.py`**: `CreateDraftBatchRequest` accepts `batch_type` + `parent_batch_id`; new `POST /draft-batches/{id}/create-content-batch` endpoint — requires all theme posts approved, creates content batch with `batch_type=content` and `parent_batch_id` set
- **`migrations/040_dma_batch_type_workflow.py`**: idempotent Alembic migration adding `batch_type`, `parent_batch_id`, FK, and indexes

### CP Backend
- **`api/marketing_review.py`**: `CreateDraftBatchInput` carries `batch_type` + `parent_batch_id`; new proxy route `POST /cp/marketing/draft-batches/{id}/create-content-batch`

### CP Frontend
- **`marketingReview.service.ts`**: `DraftBatch` type has `batch_type` + `parent_batch_id`; `CreateDraftBatchInput` carries `batch_type`; new `createContentBatchFromTheme()` service function
- **`DigitalMarketingActivationWizard.tsx`**:
  - `themeBatch` state tracks the current theme batch pending approval
  - `handleGenerateYouTubeDraft` tags batch as `theme` when only `table` artifacts are selected
  - `isThemeBatchFullyApproved` memo gates the content creation button
  - `handleCreateContentFromApprovedTheme` creates the linked content batch
  - **"Create Content from Approved Theme"** button appears only after all theme posts are approved

### Tests
- `test_dma_full_workflow.py`: 3 new tests covering `batch_type` field persistence, `create-content-from-theme` happy path, and blocked-when-not-approved guard (total: **15 tests, 1277 suite passing**)

---

## Workflow after this PR

```
1. Generate Theme Plan  (batch_type=theme, artifact_type=table)
        ↓
2. Customer approves all theme posts
        ↓ unlocks button
3. Create Content from Approved Theme  (batch_type=content, parent_batch_id=theme_id)
        ↓
4. Customer approves content posts
        ↓
5. Publish (execute) → YouTube  ← now works (secret manager package present)
```

## DB migration

Migration `040_dma_batch_type_workflow` runs automatically on deploy. Existing rows get `batch_type='direct'` (server default), no data migration needed.