### PR TITLE
feat(MOB-DMA-1): Iteration 1 — DMA services, DMAConversationScreen, ArtifactRenderer, voice wiring

### DIFF
--- a/docs/mobile/iterations/MOB-DMA-1-dma-chat-content.md
+++ b/docs/mobile/iterations/MOB-DMA-1-dma-chat-content.md
@@ -268,11 +268,11 @@ Do this BEFORE starting the next epic.
 
 | ID | Iteration | Epic | Story | TDD | BDD | Status | PR |
 |---|---|---|---|---|---|---|---|
-| E1-S1 | 1 | DMA services | Mirror DMA activation service | ⬜ | — | 🔴 Not Started | — |
-| E1-S2 | 1 | DMA services | Mirror marketing review service | ⬜ | — | 🔴 Not Started | — |
-| E2-S1 | 1 | Customer sees DMA chat | DMAConversationScreen + navigation wiring | ⬜ | — | 🔴 Not Started | — |
-| E2-S2 | 1 | Customer sees DMA chat | ArtifactRenderer component (table/image/mp4) | ⬜ | — | 🔴 Not Started | — |
-| E3-S1 | 1 | Voice as alt input | Wire voice toggle into DMAConversationScreen | ⬜ | — | 🔴 Not Started | — |
+| E1-S1 | 1 | DMA services | Mirror DMA activation service | ✅ | — | 🟢 Done | — |
+| E1-S2 | 1 | DMA services | Mirror marketing review service | ✅ | — | 🟢 Done | — |
+| E2-S1 | 1 | Customer sees DMA chat | DMAConversationScreen + navigation wiring | ✅ | — | 🟢 Done | — |
+| E2-S2 | 1 | Customer sees DMA chat | ArtifactRenderer component (table/image/mp4) | ✅ | — | 🟢 Done | — |
+| E3-S1 | 1 | Voice as alt input | Wire voice toggle into DMAConversationScreen | ✅ | — | 🟢 Done | — |
 | E4-S1 | 2 | Staged DMA workflow | Theme-to-content batch staging in DMAConversationScreen | ⬜ | — | 🔴 Not Started | — |
 | E4-S2 | 2 | Staged DMA workflow | YouTube credential ref passed to createContentBatch | ⬜ | — | 🔴 Not Started | — |
 | E5-S1 | 2 | Clean mobile ops hub | Strip placeholder sections in AgentOperationsScreen | ⬜ | — | 🔴 Not Started | — |

--- a/src/mobile/__tests__/AgentOperationsDMAChatBtn.test.tsx
+++ b/src/mobile/__tests__/AgentOperationsDMAChatBtn.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * AgentOperationsScreen DMA Chat Button Test (MOB-DMA-1 E2-S1-T6)
+ *
+ * Verifies that the "Chat with Agent" button navigates to DMAConversation
+ * when isDigitalMarketing is true.
+ */
+
+import React from 'react'
+import { render, fireEvent, waitFor } from '@testing-library/react-native'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('@/hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      black: '#0a0a0a',
+      neonCyan: '#00f2fe',
+      textPrimary: '#ffffff',
+      textSecondary: '#a1a1aa',
+      card: '#18181b',
+      error: '#ef4444',
+      success: '#10b981',
+      warning: '#f59e0b',
+      border: '#374151',
+    },
+    spacing: { xs: 4, sm: 8, md: 16, lg: 24, xl: 32, screenPadding: { horizontal: 16, vertical: 20 } },
+    typography: {
+      fontFamily: { display: 'SpaceGrotesk_700Bold', body: 'Inter_400Regular', bodyBold: 'Inter_600SemiBold' },
+    },
+  }),
+}))
+
+jest.mock('@/hooks/useHiredAgents', () => ({
+  useHiredAgentById: jest.fn(() => ({
+    data: {
+      agent_id: 'AGT-MKT-DMA-001',
+      agent_type_id: 'marketing.digital_marketing.v1',
+      nickname: 'My DMA Agent',
+      hired_instance_id: 'hi-dma-1',
+    },
+    isLoading: false,
+    error: null,
+  })),
+}))
+
+jest.mock('@/hooks/useApprovalQueue', () => ({
+  useApprovalQueue: jest.fn(() => ({
+    deliverables: [],
+    isLoading: false,
+    error: null,
+    approve: jest.fn(),
+    reject: jest.fn(),
+  })),
+}))
+
+const mockCpGet = jest.fn()
+const mockCpPatch = jest.fn()
+const mockCpPost = jest.fn(() => Promise.resolve({ data: {} }))
+
+jest.mock('@/lib/cpApiClient', () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => mockCpGet(...args),
+    patch: (...args: unknown[]) => mockCpPatch(...args),
+    post: (...args: unknown[]) => mockCpPost(...args),
+  },
+}))
+
+jest.mock('@/hooks/useAgentVoiceOverlay', () => ({
+  useAgentVoiceOverlay: jest.fn(() => ({
+    isListening: false,
+    toggle: jest.fn(),
+    lastCommand: null,
+    isAvailable: false,
+  })),
+}))
+
+jest.mock('@/components/voice/VoiceFAB', () => {
+  const React = require('react')
+  const { View } = require('react-native')
+  return {
+    VoiceFAB: (props: any) => React.createElement(View, { testID: props.testID }),
+  }
+})
+
+const mockNavigate = jest.fn()
+const mockGoBack = jest.fn()
+const mockNavigation = { navigate: mockNavigate, goBack: mockGoBack } as any
+
+const mockRoute = {
+  params: { hiredAgentId: 'hi-dma-1', focusSection: 'goals' },
+  key: 'AgentOperations-dma',
+  name: 'AgentOperations',
+} as any
+
+import { AgentOperationsScreen } from '@/screens/agents/AgentOperationsScreen'
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('AgentOperationsScreen — DMA chat button', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // Return the Theme Discovery skill so goals section shows the DMA UI
+    mockCpGet.mockResolvedValue({
+      data: [
+        {
+          skill_id: 'skill-theme-discovery',
+          name: 'theme_discovery',
+          display_name: 'Theme Discovery',
+          goal_schema: {
+            fields: [
+              { key: 'business_background', label: 'Business Background', type: 'text', required: true },
+              { key: 'industry', label: 'Industry', type: 'text', required: true },
+              { key: 'locality', label: 'Locality', type: 'text', required: true },
+            ],
+          },
+          goal_config: {},
+        },
+      ],
+    })
+    mockCpPatch.mockResolvedValue({ data: { goal_config: {} } })
+  })
+
+  it('E2-S1-T6: tapping chat-with-agent-btn navigates to DMAConversation', async () => {
+    const { getByTestId } = render(
+      <AgentOperationsScreen navigation={mockNavigation} route={mockRoute} />
+    )
+    await waitFor(() => {
+      expect(getByTestId('chat-with-agent-btn')).toBeTruthy()
+    })
+    fireEvent.press(getByTestId('chat-with-agent-btn'))
+    expect(mockNavigate).toHaveBeenCalledWith('DMAConversation', { hiredAgentId: expect.any(String) })
+  })
+})

--- a/src/mobile/__tests__/ArtifactRenderer.test.tsx
+++ b/src/mobile/__tests__/ArtifactRenderer.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import { ArtifactRenderer } from '@/components/ArtifactRenderer'
+import type { DraftPost } from '@/services/marketingReview.service'
+
+jest.mock('@/hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      black: '#0a0a0a',
+      neonCyan: '#00f2fe',
+      textPrimary: '#ffffff',
+      textSecondary: '#a1a1aa',
+    },
+    typography: {
+      fontFamily: { display: 'SpaceGrotesk_700Bold', body: 'Inter_400Regular', bodyBold: 'Inter_600SemiBold' },
+    },
+  }),
+}))
+
+jest.mock('react-native/Libraries/Utilities/Platform', () => ({ OS: 'ios' }))
+
+const makePost = (overrides: Partial<DraftPost>): DraftPost => ({
+  post_id: 'p1',
+  channel: 'youtube',
+  text: 'test post',
+  review_status: 'pending_review',
+  ...overrides,
+})
+
+describe('ArtifactRenderer', () => {
+  it('E2-S2-T1: renders artifact-image for image type', () => {
+    const { getByTestId } = render(
+      <ArtifactRenderer post={makePost({ artifact_type: 'image', artifact_uri: 'https://img.jpg' })} />
+    )
+    expect(getByTestId('artifact-image')).toBeTruthy()
+  })
+
+  it('E2-S2-T2: renders artifact-video with play text for video type', () => {
+    const { getByTestId, getByText } = render(
+      <ArtifactRenderer post={makePost({ artifact_type: 'video', artifact_uri: 'https://vid.mp4' })} />
+    )
+    expect(getByTestId('artifact-video')).toBeTruthy()
+    expect(getByText('▶ Play video')).toBeTruthy()
+  })
+
+  it('E2-S2-T3: renders artifact-table for table type with valid JSON', () => {
+    const { getByTestId } = render(
+      <ArtifactRenderer
+        post={makePost({ artifact_type: 'table', artifact_uri: '[{"col":"val"}]' })}
+      />
+    )
+    expect(getByTestId('artifact-table')).toBeTruthy()
+  })
+
+  it('E2-S2-T4: shows generating text when status is running', () => {
+    const { getByText } = render(
+      <ArtifactRenderer
+        post={makePost({ artifact_generation_status: 'running' })}
+      />
+    )
+    expect(getByText('Generating artifact…')).toBeTruthy()
+  })
+
+  it('E2-S2-T5: shows failed text when status is failed', () => {
+    const { getByText } = render(
+      <ArtifactRenderer
+        post={makePost({ artifact_generation_status: 'failed' })}
+      />
+    )
+    expect(getByText('Artifact generation failed')).toBeTruthy()
+  })
+
+  it('E2-S2-T6: renders nothing for text type', () => {
+    const { toJSON } = render(
+      <ArtifactRenderer post={makePost({ artifact_type: 'text', artifact_uri: 'some text' })} />
+    )
+    expect(toJSON()).toBeNull()
+  })
+})

--- a/src/mobile/__tests__/DMAConversationScreen.test.tsx
+++ b/src/mobile/__tests__/DMAConversationScreen.test.tsx
@@ -1,0 +1,225 @@
+import React from 'react'
+import { render, fireEvent, waitFor } from '@testing-library/react-native'
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('@/hooks/useTheme', () => ({
+  useTheme: () => ({
+    colors: {
+      black: '#0a0a0a',
+      neonCyan: '#00f2fe',
+      textPrimary: '#ffffff',
+      textSecondary: '#a1a1aa',
+      card: '#18181b',
+      error: '#ef4444',
+      success: '#10b981',
+      warning: '#f59e0b',
+      border: '#374151',
+    },
+    spacing: { xs: 4, sm: 8, md: 16, lg: 24, xl: 32, screenPadding: { horizontal: 16, vertical: 20 } },
+    typography: {
+      fontFamily: { display: 'SpaceGrotesk_700Bold', body: 'Inter_400Regular', bodyBold: 'Inter_600SemiBold' },
+    },
+  }),
+}))
+
+const mockGetWorkspace = jest.fn()
+const mockPatchWorkspace = jest.fn()
+
+jest.mock('@/services/digitalMarketingActivation.service', () => ({
+  getDigitalMarketingActivationWorkspace: (...args: unknown[]) => mockGetWorkspace(...args),
+  patchDigitalMarketingActivationWorkspace: (...args: unknown[]) => mockPatchWorkspace(...args),
+}))
+
+const mockToggle = jest.fn()
+jest.mock('@/hooks/useAgentVoiceOverlay', () => ({
+  useAgentVoiceOverlay: jest.fn(() => ({
+    isListening: false,
+    toggle: mockToggle,
+    lastCommand: null,
+    isAvailable: false,
+  })),
+}))
+
+jest.mock('@/components/voice/VoiceFAB', () => {
+  const React = require('react')
+  const { View } = require('react-native')
+  return {
+    VoiceFAB: (props: any) => React.createElement(View, { testID: props.testID }),
+  }
+})
+
+jest.mock('@/components/ArtifactRenderer', () => ({
+  ArtifactRenderer: () => null,
+}))
+
+const mockNavigate = jest.fn()
+const mockGoBack = jest.fn()
+
+const makeNavigation = () => ({ navigate: mockNavigate, goBack: mockGoBack } as any)
+const makeRoute = (hiredAgentId = 'ha-1') => ({
+  params: { hiredAgentId },
+  key: 'DMAConversation-1',
+  name: 'DMAConversation',
+} as any)
+
+const makeWorkspaceResp = (messages: { role: string; content: string }[] = []) => ({
+  hired_instance_id: 'ha-1',
+  agent_type_id: 'marketing.digital_marketing.v1',
+  workspace: {
+    campaign_setup: {
+      strategy_workshop: { messages },
+    },
+  },
+  readiness: { brief_complete: false, youtube_selected: false, youtube_connection_ready: false, configured: false, can_finalize: false, missing_requirements: [] },
+  updated_at: '2026-01-01T00:00:00Z',
+})
+
+import { DMAConversationScreen } from '@/screens/agents/DMAConversationScreen'
+import { useAgentVoiceOverlay } from '@/hooks/useAgentVoiceOverlay'
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('DMAConversationScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(useAgentVoiceOverlay as jest.Mock).mockReturnValue({
+      isListening: false,
+      toggle: mockToggle,
+      lastCommand: null,
+      isAvailable: false,
+    })
+  })
+
+  it('E2-S1-T1: shows both message bubbles when workspace has 2 messages', async () => {
+    mockGetWorkspace.mockResolvedValueOnce(
+      makeWorkspaceResp([
+        { role: 'assistant', content: 'Hello, tell me about your business.' },
+        { role: 'user', content: 'We sell dental services.' },
+      ])
+    )
+    const { getByText } = render(
+      <DMAConversationScreen navigation={makeNavigation()} route={makeRoute()} />
+    )
+    await waitFor(() => {
+      expect(getByText('Hello, tell me about your business.')).toBeTruthy()
+      expect(getByText('We sell dental services.')).toBeTruthy()
+    })
+  })
+
+  it('E2-S1-T2: shows error banner when workspace load throws', async () => {
+    mockGetWorkspace.mockRejectedValueOnce(new Error('network error'))
+    const { getByText } = render(
+      <DMAConversationScreen navigation={makeNavigation()} route={makeRoute()} />
+    )
+    await waitFor(() => {
+      expect(getByText('Failed to load conversation. Please try again.')).toBeTruthy()
+    })
+  })
+
+  it('E2-S1-T3: calls patch with user message when Send is pressed', async () => {
+    mockGetWorkspace.mockResolvedValueOnce(makeWorkspaceResp([]))
+    mockPatchWorkspace.mockResolvedValueOnce(makeWorkspaceResp([{ role: 'user', content: 'hello' }]))
+
+    const { getByTestId } = render(
+      <DMAConversationScreen navigation={makeNavigation()} route={makeRoute()} />
+    )
+    await waitFor(() => {
+      expect(getByTestId('dma-chat-input')).toBeTruthy()
+    })
+
+    fireEvent.changeText(getByTestId('dma-chat-input'), 'hello')
+    fireEvent.press(getByTestId('dma-chat-send'))
+
+    await waitFor(() => {
+      expect(mockPatchWorkspace).toHaveBeenCalled()
+      const patchArgs = mockPatchWorkspace.mock.calls[0]
+      const messages = patchArgs[1]?.campaign_setup?.strategy_workshop?.messages
+      expect(Array.isArray(messages)).toBe(true)
+      expect(messages.some((m: any) => m.role === 'user' && m.content === 'hello')).toBe(true)
+    })
+  })
+
+  it('E2-S1-T4: shows empty-state hint when messages is empty', async () => {
+    mockGetWorkspace.mockResolvedValueOnce(makeWorkspaceResp([]))
+    const { getByText } = render(
+      <DMAConversationScreen navigation={makeNavigation()} route={makeRoute()} />
+    )
+    await waitFor(() => {
+      expect(
+        getByText('Start the strategy workshop — describe your business, audience, and goals.')
+      ).toBeTruthy()
+    })
+  })
+
+  it('E2-S1-T5: shows ActivityIndicator while workspace promise is pending', () => {
+    // Never-resolving promise
+    mockGetWorkspace.mockReturnValueOnce(new Promise(() => {}))
+    const { UNSAFE_getAllByType } = render(
+      <DMAConversationScreen navigation={makeNavigation()} route={makeRoute()} />
+    )
+    const { ActivityIndicator } = require('react-native')
+    const indicators = UNSAFE_getAllByType(ActivityIndicator)
+    expect(indicators.length).toBeGreaterThan(0)
+  })
+
+  it('E3-S1-T1: renders voice-fab-dma when useAgentVoiceOverlay returns isAvailable true', async () => {
+    ;(useAgentVoiceOverlay as jest.Mock).mockReturnValue({
+      isListening: false,
+      toggle: mockToggle,
+      lastCommand: null,
+      isAvailable: true,
+    })
+    mockGetWorkspace.mockResolvedValueOnce(makeWorkspaceResp([]))
+    const { getByTestId } = render(
+      <DMAConversationScreen navigation={makeNavigation()} route={makeRoute()} />
+    )
+    await waitFor(() => {
+      expect(getByTestId('voice-fab-dma')).toBeTruthy()
+    })
+  })
+
+  it('E3-S1-T2: does not render voice-fab-dma and still shows input when isAvailable false', async () => {
+    ;(useAgentVoiceOverlay as jest.Mock).mockReturnValue({
+      isListening: false,
+      toggle: jest.fn(),
+      lastCommand: null,
+      isAvailable: false,
+    })
+    mockGetWorkspace.mockResolvedValueOnce(makeWorkspaceResp([]))
+    const { queryByTestId, getByTestId } = render(
+      <DMAConversationScreen navigation={makeNavigation()} route={makeRoute()} />
+    )
+    await waitFor(() => {
+      expect(queryByTestId('voice-fab-dma')).toBeNull()
+      expect(getByTestId('dma-chat-input')).toBeTruthy()
+    })
+  })
+
+  it('E3-S1-T3: voice "send message" command calls patch (handleSend executes)', async () => {
+    let capturedCommands: any = null
+    ;(useAgentVoiceOverlay as jest.Mock).mockImplementation((commands: any) => {
+      capturedCommands = commands
+      return { isListening: false, toggle: jest.fn(), lastCommand: null, isAvailable: true }
+    })
+    mockGetWorkspace.mockResolvedValueOnce(makeWorkspaceResp([]))
+    mockPatchWorkspace.mockResolvedValue(makeWorkspaceResp([]))
+
+    const { getByTestId } = render(
+      <DMAConversationScreen navigation={makeNavigation()} route={makeRoute()} />
+    )
+    await waitFor(() => {
+      expect(getByTestId('dma-chat-input')).toBeTruthy()
+    })
+
+    // Give the input some text so handleSend will not early-exit on empty
+    fireEvent.changeText(getByTestId('dma-chat-input'), 'voice triggered')
+
+    // Re-render captures the latest capturedCommands via closure
+    expect(capturedCommands).not.toBeNull()
+    expect(typeof capturedCommands['send message']).toBe('function')
+
+    await capturedCommands['send message']('')
+    expect(mockPatchWorkspace).toHaveBeenCalled()
+  })
+})

--- a/src/mobile/__tests__/digitalMarketingActivation.service.test.ts
+++ b/src/mobile/__tests__/digitalMarketingActivation.service.test.ts
@@ -1,0 +1,83 @@
+import cpApiClient from '@/lib/cpApiClient'
+import {
+  getDigitalMarketingActivationWorkspace,
+  upsertDigitalMarketingActivationWorkspace,
+  patchDigitalMarketingActivationWorkspace,
+  generateDigitalMarketingThemePlan,
+} from '@/services/digitalMarketingActivation.service'
+
+jest.mock('@/lib/cpApiClient', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    put: jest.fn(),
+    patch: jest.fn(),
+    post: jest.fn(),
+  },
+}))
+
+const mockGet = (cpApiClient.get as jest.Mock)
+const mockPut = (cpApiClient.put as jest.Mock)
+const mockPatch = (cpApiClient.patch as jest.Mock)
+const mockPost = (cpApiClient.post as jest.Mock)
+
+const mockWorkspaceResponse = {
+  hired_instance_id: 'x',
+  agent_type_id: 'marketing.digital_marketing.v1',
+  workspace: {},
+  readiness: {
+    brief_complete: false,
+    youtube_selected: false,
+    youtube_connection_ready: false,
+    configured: false,
+    can_finalize: false,
+    missing_requirements: [],
+  },
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+describe('digitalMarketingActivation.service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('E1-S1-T1: getDigitalMarketingActivationWorkspace resolves with hired_instance_id', async () => {
+    mockGet.mockResolvedValueOnce({ data: mockWorkspaceResponse })
+    const result = await getDigitalMarketingActivationWorkspace('x')
+    expect(result.hired_instance_id).toBe('x')
+  })
+
+  it('E1-S1-T2: upsertDigitalMarketingActivationWorkspace calls put with path containing /x', async () => {
+    mockPut.mockResolvedValueOnce({ data: mockWorkspaceResponse })
+    await upsertDigitalMarketingActivationWorkspace('x', { workspace: {} } as any)
+    const callArgs = mockPut.mock.calls[0]
+    expect(callArgs[0]).toContain('/x')
+  })
+
+  it('E1-S1-T3: generateDigitalMarketingThemePlan calls path ending in /generate-theme-plan', async () => {
+    const mockResp = {
+      master_theme: 'test',
+      derived_themes: [],
+      workspace: mockWorkspaceResponse,
+    }
+    mockPost.mockResolvedValueOnce({ data: mockResp })
+    await generateDigitalMarketingThemePlan('x')
+    const callArgs = mockPost.mock.calls[0]
+    expect(callArgs[0]).toMatch(/\/generate-theme-plan$/)
+  })
+
+  it('E1-S1-T4: patchDigitalMarketingActivationWorkspace rejects when cpApiClient.patch rejects', async () => {
+    mockPatch.mockRejectedValueOnce(new Error('500'))
+    await expect(patchDigitalMarketingActivationWorkspace('x', {})).rejects.toThrow('500')
+  })
+
+  it('E1-S1-T5: patchDigitalMarketingActivationWorkspace includes X-Correlation-ID header', async () => {
+    mockPatch.mockResolvedValueOnce({ data: mockWorkspaceResponse })
+    await patchDigitalMarketingActivationWorkspace('x', {})
+    const callArgs = mockPatch.mock.calls[0]
+    const headers = (callArgs[2] as { headers?: Record<string, string> })?.headers
+    expect(headers).toBeDefined()
+    expect(typeof headers!['X-Correlation-ID']).toBe('string')
+    expect(headers!['X-Correlation-ID'].length).toBeGreaterThan(0)
+  })
+})

--- a/src/mobile/__tests__/marketingReview.service.test.ts
+++ b/src/mobile/__tests__/marketingReview.service.test.ts
@@ -1,0 +1,64 @@
+import cpApiClient from '@/lib/cpApiClient'
+import {
+  listCustomerDraftBatches,
+  createDraftBatch,
+  approveDraftPost,
+  rejectDraftPost,
+  createContentBatchFromTheme,
+} from '@/services/marketingReview.service'
+
+jest.mock('@/lib/cpApiClient', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+    post: jest.fn(),
+  },
+}))
+
+const mockGet = (cpApiClient.get as jest.Mock)
+const mockPost = (cpApiClient.post as jest.Mock)
+
+const mockBatch = {
+  batch_id: 'b1',
+  agent_id: 'agt1',
+  theme: 'test theme',
+  brand_name: 'Test Brand',
+  created_at: '2026-01-01T00:00:00Z',
+  status: 'draft',
+  posts: [],
+}
+
+describe('marketingReview.service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('E1-S2-T1: listCustomerDraftBatches resolves with empty array', async () => {
+    mockGet.mockResolvedValueOnce({ data: [] })
+    const result = await listCustomerDraftBatches()
+    expect(result).toEqual([])
+  })
+
+  it('E1-S2-T2: approveDraftPost resolves with review_status approved', async () => {
+    mockPost.mockResolvedValueOnce({
+      data: { post_id: 'p1', review_status: 'approved', approval_id: 'a1' },
+    })
+    const result = await approveDraftPost('p1')
+    expect(result.review_status).toBe('approved')
+  })
+
+  it('E1-S2-T3: createContentBatchFromTheme calls URL containing b1/create-content-batch', async () => {
+    mockPost.mockResolvedValueOnce({ data: mockBatch })
+    await createContentBatchFromTheme('b1', {})
+    const callArgs = mockPost.mock.calls[0]
+    expect(callArgs[0]).toContain('b1/create-content-batch')
+  })
+
+  it('E1-S2-T4: rejectDraftPost calls correct path with post_id and reason', async () => {
+    mockPost.mockResolvedValueOnce({ data: { post_id: 'p1', decision: 'rejected' } })
+    await rejectDraftPost('p1', 'off-brand')
+    const callArgs = mockPost.mock.calls[0]
+    expect(callArgs[0]).toBe('/cp/marketing/draft-posts/reject')
+    expect(callArgs[1]).toEqual({ post_id: 'p1', reason: 'off-brand' })
+  })
+})

--- a/src/mobile/src/components/ArtifactRenderer.tsx
+++ b/src/mobile/src/components/ArtifactRenderer.tsx
@@ -97,7 +97,7 @@ export const ArtifactRenderer = ({ post }: Props) => {
       )
     }
     return (
-      <View style={[s.table, { borderColor: colors.textSecondary + '30' }]}>
+      <View style={[s.table, { borderColor: colors.textSecondary + '30' }]} testID="artifact-table">
         <View style={[s.trow, { backgroundColor: '#27272a' }]}>
           {headers.map((h) => (
             <Text key={h} style={[s.th, { color: colors.textPrimary }]}>
@@ -109,7 +109,6 @@ export const ArtifactRenderer = ({ post }: Props) => {
           data={rows}
           keyExtractor={(_, i) => String(i)}
           scrollEnabled={false}
-          testID="artifact-table"
           renderItem={({ item, index }) => (
             <View
               style={[

--- a/src/mobile/src/components/ArtifactRenderer.tsx
+++ b/src/mobile/src/components/ArtifactRenderer.tsx
@@ -1,0 +1,151 @@
+import React from 'react'
+import {
+  View,
+  Text,
+  Image,
+  TouchableOpacity,
+  FlatList,
+  ActivityIndicator,
+  Linking,
+  StyleSheet,
+} from 'react-native'
+import { useTheme } from '@/hooks/useTheme'
+import type { DraftPost } from '@/services/marketingReview.service'
+
+interface Props {
+  post: DraftPost
+}
+
+export const ArtifactRenderer = ({ post }: Props) => {
+  const { colors } = useTheme()
+  const status = post.artifact_generation_status
+
+  if (status === 'queued' || status === 'running') {
+    return (
+      <View style={s.row}>
+        <ActivityIndicator color={colors.neonCyan} size="small" />
+        <Text style={{ color: colors.textSecondary, marginLeft: 8 }}>Generating artifact…</Text>
+      </View>
+    )
+  }
+
+  if (status === 'failed') {
+    return (
+      <View style={[s.banner, { borderColor: '#ef444455', backgroundColor: '#ef444418' }]}>
+        <Text style={{ color: '#ef4444' }}>Artifact generation failed</Text>
+      </View>
+    )
+  }
+
+  const type = post.artifact_type
+  const uri = post.artifact_uri
+  if (!type || type === 'text' || !uri) return null
+
+  if (type === 'image') {
+    return (
+      <Image
+        source={{ uri }}
+        style={s.img}
+        resizeMode="cover"
+        testID="artifact-image"
+        accessibilityLabel="Content image"
+      />
+    )
+  }
+
+  if (type === 'video' || type === 'video_audio') {
+    return (
+      <TouchableOpacity
+        style={[
+          s.videoCard,
+          { borderColor: colors.textSecondary + '30', backgroundColor: '#18181b' },
+        ]}
+        onPress={() => Linking.openURL(uri)}
+        testID="artifact-video"
+        accessibilityLabel="Play video"
+      >
+        {post.artifact_preview_uri ? (
+          <Image
+            source={{ uri: post.artifact_preview_uri }}
+            style={s.thumb}
+            resizeMode="cover"
+          />
+        ) : null}
+        <Text style={{ color: colors.neonCyan, fontWeight: '700', marginTop: 8 }}>
+          ▶ Play video
+        </Text>
+      </TouchableOpacity>
+    )
+  }
+
+  if (type === 'table') {
+    let rows: Record<string, string>[] = []
+    let headers: string[] = []
+    try {
+      const parsed = JSON.parse(uri)
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        headers = Object.keys(parsed[0])
+        rows = parsed
+      }
+    } catch {
+      return (
+        <View
+          style={[s.banner, { borderColor: '#f59e0b55', backgroundColor: '#f59e0b18' }]}
+        >
+          <Text style={{ color: '#f59e0b' }}>Table data could not be parsed</Text>
+        </View>
+      )
+    }
+    return (
+      <View style={[s.table, { borderColor: colors.textSecondary + '30' }]}>
+        <View style={[s.trow, { backgroundColor: '#27272a' }]}>
+          {headers.map((h) => (
+            <Text key={h} style={[s.th, { color: colors.textPrimary }]}>
+              {h}
+            </Text>
+          ))}
+        </View>
+        <FlatList
+          data={rows}
+          keyExtractor={(_, i) => String(i)}
+          scrollEnabled={false}
+          testID="artifact-table"
+          renderItem={({ item, index }) => (
+            <View
+              style={[
+                s.trow,
+                { backgroundColor: index % 2 === 0 ? '#18181b' : '#1c1c1f' },
+              ]}
+            >
+              {headers.map((h) => (
+                <Text key={h} style={[s.td, { color: colors.textSecondary }]}>
+                  {String((item as Record<string, string>)[h] ?? '')}
+                </Text>
+              ))}
+            </View>
+          )}
+        />
+      </View>
+    )
+  }
+
+  return null
+}
+
+const s = StyleSheet.create({
+  row: { flexDirection: 'row', alignItems: 'center', padding: 8 },
+  banner: { borderWidth: 1, borderRadius: 8, padding: 10, marginVertical: 4 },
+  img: { width: '100%', height: 200, borderRadius: 10, marginVertical: 4 },
+  videoCard: {
+    borderWidth: 1,
+    borderRadius: 10,
+    padding: 12,
+    alignItems: 'center',
+    marginVertical: 4,
+  },
+  thumb: { width: '100%', height: 100, borderRadius: 8 },
+  table: { borderWidth: 1, borderRadius: 8, overflow: 'hidden', marginVertical: 4 },
+  trow: { flexDirection: 'row' },
+  th: { flex: 1, padding: 8, fontSize: 12, fontWeight: '700' },
+  td: { flex: 1, padding: 8, fontSize: 12 },
+})

--- a/src/mobile/src/navigation/MainNavigator.tsx
+++ b/src/mobile/src/navigation/MainNavigator.tsx
@@ -25,7 +25,7 @@ import { HomeScreen } from "../screens/home/HomeScreen";
 import { DiscoverScreen } from "../screens/discover/DiscoverScreen";
 import { AgentDetailScreen } from "../screens/discover/AgentDetailScreen";
 import { HireWizardScreen } from "../screens/hire/HireWizardScreen";
-import { MyAgentsScreen, TrialDashboardScreen, ActiveTrialsListScreen, HiredAgentsListScreen, AgentOperationsScreen, InboxScreen, ContentAnalyticsScreen, PlatformConnectionsScreen } from "../screens/agents";
+import { MyAgentsScreen, TrialDashboardScreen, ActiveTrialsListScreen, HiredAgentsListScreen, AgentOperationsScreen, InboxScreen, ContentAnalyticsScreen, PlatformConnectionsScreen, DMAConversationScreen } from "../screens/agents";
 import { ProfileScreen } from "../screens/profile/ProfileScreen";
 import { EditProfileScreen } from "../screens/profile/EditProfileScreen";
 import { SettingsScreen, NotificationsScreen, HelpCenterScreen, PrivacyPolicyScreen, TermsOfServiceScreen, PaymentMethodsScreen, SubscriptionManagementScreen, UsageBillingScreen } from "../screens/profile";
@@ -102,6 +102,7 @@ const MyAgentsNavigator = () => {
       <MyAgentsStack.Screen name="Inbox" component={InboxScreen} />
       <MyAgentsStack.Screen name="ContentAnalytics" component={ContentAnalyticsScreen} />
       <MyAgentsStack.Screen name="PlatformConnections" component={PlatformConnectionsScreen} />
+      <MyAgentsStack.Screen name="DMAConversation" component={DMAConversationScreen} />
     </MyAgentsStack.Navigator>
   );
 };

--- a/src/mobile/src/navigation/types.ts
+++ b/src/mobile/src/navigation/types.ts
@@ -113,6 +113,7 @@ export type MyAgentsStackParamList = {
   Inbox: undefined;
   ContentAnalytics: { hiredAgentId: string };
   PlatformConnections: { hiredAgentId: string };
+  DMAConversation: { hiredAgentId: string };
 };
 
 export type AgentOperationsFocusSection =

--- a/src/mobile/src/screens/agents/AgentOperationsScreen.tsx
+++ b/src/mobile/src/screens/agents/AgentOperationsScreen.tsx
@@ -693,6 +693,16 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
                           fields={visibleBriefFields}
                           values={briefValues}
                         />
+                        <TouchableOpacity
+                          style={[styles.actionBtn, { backgroundColor: colors.neonCyan + '22', marginTop: 12 }]}
+                          onPress={() => navigation.navigate('DMAConversation', { hiredAgentId })}
+                          testID="chat-with-agent-btn"
+                          accessibilityLabel="Chat with Agent"
+                        >
+                          <Text style={{ color: colors.neonCyan, fontSize: 14, fontWeight: '600' }}>
+                            💬 Chat with Agent
+                          </Text>
+                        </TouchableOpacity>
                       </View>
                     ) : null}
                   </View>

--- a/src/mobile/src/screens/agents/DMAConversationScreen.tsx
+++ b/src/mobile/src/screens/agents/DMAConversationScreen.tsx
@@ -1,0 +1,244 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react'
+import {
+  SafeAreaView,
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  ScrollView,
+  ActivityIndicator,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native'
+import { useTheme } from '@/hooks/useTheme'
+import {
+  getDigitalMarketingActivationWorkspace,
+  patchDigitalMarketingActivationWorkspace,
+  type DigitalMarketingStrategyWorkshopMessage,
+} from '@/services/digitalMarketingActivation.service'
+import { ArtifactRenderer } from '@/components/ArtifactRenderer'
+import { VoiceFAB } from '@/components/voice/VoiceFAB'
+import { useAgentVoiceOverlay } from '@/hooks/useAgentVoiceOverlay'
+import type { MyAgentsStackScreenProps } from '@/navigation/types'
+import type { DraftPost } from '@/services/marketingReview.service'
+
+type Props = MyAgentsStackScreenProps<'DMAConversation'>
+
+export const DMAConversationScreen = ({ navigation, route }: Props) => {
+  const { hiredAgentId } = route.params
+  const { colors, typography } = useTheme()
+  const scrollRef = useRef<ScrollView>(null)
+
+  const [messages, setMessages] = useState<DigitalMarketingStrategyWorkshopMessage[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [inputText, setInputText] = useState('')
+  const [sending, setSending] = useState(false)
+
+  useEffect(() => {
+    getDigitalMarketingActivationWorkspace(hiredAgentId)
+      .then((resp) => {
+        setMessages(resp.workspace?.campaign_setup?.strategy_workshop?.messages ?? [])
+      })
+      .catch(() => setError('Failed to load conversation. Please try again.'))
+      .finally(() => setLoading(false))
+  }, [hiredAgentId])
+
+  const handleSend = useCallback(async () => {
+    const text = inputText.trim()
+    if (!text || sending) return
+    const userMsg: DigitalMarketingStrategyWorkshopMessage = { role: 'user', content: text }
+    setMessages((prev) => [...prev, userMsg])
+    setInputText('')
+    setSending(true)
+    try {
+      const resp = await patchDigitalMarketingActivationWorkspace(hiredAgentId, {
+        campaign_setup: { strategy_workshop: { messages: [...messages, userMsg] } },
+      })
+      setMessages(resp.workspace?.campaign_setup?.strategy_workshop?.messages ?? [])
+    } catch {
+      setError('Failed to send message. Please try again.')
+    } finally {
+      setSending(false)
+      setTimeout(() => scrollRef.current?.scrollToEnd({ animated: true }), 100)
+    }
+  }, [hiredAgentId, inputText, messages, sending])
+
+  const { isListening: voiceListening, toggle: voiceToggle, isAvailable: voiceAvailable } =
+    useAgentVoiceOverlay({ 'send message': handleSend })
+
+  // Placeholder post stub until E4-S1 wires real batch data
+  const mockPost = { artifact_type: undefined } as unknown as DraftPost
+
+  if (loading) {
+    return (
+      <SafeAreaView style={[s.root, { backgroundColor: colors.black }]}>
+        <ActivityIndicator color={colors.neonCyan} style={{ flex: 1 }} />
+      </SafeAreaView>
+    )
+  }
+
+  return (
+    <SafeAreaView
+      style={[s.root, { backgroundColor: colors.black }]}
+      testID="dma-conversation-screen"
+    >
+      <View style={[s.header, { borderBottomColor: colors.textSecondary + '20' }]}>
+        <TouchableOpacity onPress={() => navigation.goBack()}>
+          <Text style={{ color: colors.neonCyan, fontSize: 14 }}>← Back</Text>
+        </TouchableOpacity>
+        <Text
+          style={[
+            s.title,
+            { color: colors.textPrimary, fontFamily: typography.fontFamily.display },
+          ]}
+        >
+          Strategy Workshop
+        </Text>
+      </View>
+
+      {error ? (
+        <View
+          style={[s.errorBanner, { backgroundColor: '#ef444418', borderColor: '#ef444455' }]}
+        >
+          <Text style={{ color: '#ef4444' }}>{error}</Text>
+        </View>
+      ) : null}
+
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        keyboardVerticalOffset={80}
+      >
+        <ScrollView
+          ref={scrollRef}
+          contentContainerStyle={{ padding: 16, gap: 12 }}
+          onContentSizeChange={() => scrollRef.current?.scrollToEnd({ animated: false })}
+        >
+          {messages.length === 0 ? (
+            <Text
+              style={{ color: colors.textSecondary, textAlign: 'center', marginTop: 40 }}
+            >
+              Start the strategy workshop — describe your business, audience, and goals.
+            </Text>
+          ) : (
+            messages.map((msg, i) => (
+              <View
+                key={i}
+                style={[
+                  s.bubble,
+                  msg.role === 'user'
+                    ? {
+                        alignSelf: 'flex-end',
+                        backgroundColor: '#667eea22',
+                        borderColor: '#667eea55',
+                      }
+                    : {
+                        alignSelf: 'flex-start',
+                        backgroundColor: '#18181b',
+                        borderColor: colors.textSecondary + '30',
+                      },
+                ]}
+              >
+                <Text style={{ color: colors.textPrimary, fontSize: 14 }}>{msg.content}</Text>
+              </View>
+            ))
+          )}
+          {sending ? (
+            <ActivityIndicator
+              color={colors.neonCyan}
+              style={{ alignSelf: 'flex-start', marginLeft: 16 }}
+            />
+          ) : null}
+          {messages.length > 0 ? <ArtifactRenderer post={mockPost} /> : null}
+        </ScrollView>
+
+        <View
+          style={[
+            s.inputBar,
+            {
+              borderTopColor: colors.textSecondary + '20',
+              backgroundColor: colors.black,
+            },
+          ]}
+        >
+          <TextInput
+            style={[
+              s.textInput,
+              { color: colors.textPrimary, borderColor: colors.textSecondary + '40' },
+            ]}
+            value={inputText}
+            onChangeText={setInputText}
+            placeholder="Type your message…"
+            placeholderTextColor={colors.textSecondary}
+            multiline
+            editable={!sending}
+            testID="dma-chat-input"
+          />
+          <TouchableOpacity
+            style={[
+              s.sendBtn,
+              {
+                backgroundColor:
+                  sending || !inputText.trim()
+                    ? colors.textSecondary + '40'
+                    : colors.neonCyan,
+              },
+            ]}
+            onPress={handleSend}
+            disabled={sending || !inputText.trim()}
+            testID="dma-chat-send"
+          >
+            <Text style={{ color: '#0a0a0a', fontWeight: '700', fontSize: 13 }}>Send</Text>
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+      {voiceAvailable && (
+        <VoiceFAB
+          isListening={voiceListening}
+          onPress={voiceToggle}
+          testID="voice-fab-dma"
+          position="bottom-left"
+        />
+      )}
+    </SafeAreaView>
+  )
+}
+
+const s = StyleSheet.create({
+  root: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    padding: 16,
+    borderBottomWidth: 1,
+  },
+  title: { flex: 1, fontSize: 18, fontWeight: 'bold' },
+  errorBanner: { margin: 12, padding: 12, borderRadius: 8, borderWidth: 1 },
+  bubble: { maxWidth: '80%', borderRadius: 12, borderWidth: 1, padding: 12 },
+  inputBar: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: 10,
+    padding: 12,
+    borderTopWidth: 1,
+  },
+  textInput: {
+    flex: 1,
+    borderWidth: 1,
+    borderRadius: 10,
+    padding: 10,
+    minHeight: 40,
+    maxHeight: 120,
+    fontSize: 14,
+  },
+  sendBtn: {
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+})

--- a/src/mobile/src/screens/agents/index.ts
+++ b/src/mobile/src/screens/agents/index.ts
@@ -9,4 +9,4 @@ export { HiredAgentsListScreen } from './HiredAgentsListScreen';
 export { AgentOperationsScreen } from './AgentOperationsScreen';
 export { InboxScreen } from './InboxScreen';
 export { ContentAnalyticsScreen } from './ContentAnalyticsScreen';
-export { PlatformConnectionsScreen } from './PlatformConnectionsScreen';
+export { DMAConversationScreen } from './DMAConversationScreen';

--- a/src/mobile/src/screens/agents/index.ts
+++ b/src/mobile/src/screens/agents/index.ts
@@ -9,4 +9,5 @@ export { HiredAgentsListScreen } from './HiredAgentsListScreen';
 export { AgentOperationsScreen } from './AgentOperationsScreen';
 export { InboxScreen } from './InboxScreen';
 export { ContentAnalyticsScreen } from './ContentAnalyticsScreen';
+export { PlatformConnectionsScreen } from './PlatformConnectionsScreen';
 export { DMAConversationScreen } from './DMAConversationScreen';

--- a/src/mobile/src/services/digitalMarketingActivation.service.ts
+++ b/src/mobile/src/services/digitalMarketingActivation.service.ts
@@ -1,0 +1,218 @@
+import cpApiClient from '@/lib/cpApiClient'
+
+function generateCorrelationId(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}
+
+export type DigitalMarketingPlatformKey =
+  | 'youtube'
+  | 'instagram'
+  | 'facebook'
+  | 'linkedin'
+  | 'whatsapp'
+  | 'x'
+  | 'twitter'
+
+export type DigitalMarketingPlatformBinding = {
+  skill_id?: string
+  credential_id?: string
+  credential_ref?: string
+  customer_platform_credential_id?: string
+  connected?: boolean
+}
+
+export type DigitalMarketingDerivedTheme = {
+  title: string
+  description?: string
+  frequency?: string
+}
+
+export type DigitalMarketingPlatformStep = {
+  platform_key: string
+  complete: boolean
+  status?: string
+}
+
+export type DigitalMarketingCampaignSchedule = {
+  start_date: string
+  posts_per_week: number
+  preferred_days: string[]
+  preferred_hours_utc: number[]
+}
+
+export type DigitalMarketingStrategyWorkshopMessage = {
+  role: 'assistant' | 'user'
+  content: string
+}
+
+export type DigitalMarketingStrategyWorkshopSummary = {
+  profession_name?: string
+  location_focus?: string
+  customer_profile?: string
+  service_focus?: string
+  signature_differentiator?: string
+  business_goal?: string
+  first_content_direction?: string
+  business_focus?: string
+  audience?: string
+  positioning?: string
+  tone?: string
+  content_pillars?: string[]
+  youtube_angle?: string
+  cta?: string
+}
+
+export type DigitalMarketingStrategyWorkshop = {
+  status?: 'not_started' | 'discovery' | 'approval_ready' | 'approved'
+  assistant_message?: string
+  checkpoint_summary?: string
+  current_focus_question?: string
+  next_step_options?: string[]
+  time_saving_note?: string
+  follow_up_questions?: string[]
+  messages?: DigitalMarketingStrategyWorkshopMessage[]
+  summary?: DigitalMarketingStrategyWorkshopSummary
+  approved_at?: string | null
+  brief_progress?: {
+    filled: number
+    total: number
+    missing_fields: string[]
+    locked_fields: Record<string, string>
+  }
+  performance_insights?: {
+    top_performing_dimensions: string[]
+    best_posting_hours: number[]
+    avg_engagement_rate: number
+    recommendation_summary: string
+  }
+}
+
+export type DigitalMarketingCampaignSetup = {
+  campaign_id?: string | null
+  master_theme?: string
+  derived_themes?: DigitalMarketingDerivedTheme[]
+  schedule?: Partial<DigitalMarketingCampaignSchedule>
+  strategy_workshop?: DigitalMarketingStrategyWorkshop
+}
+
+export type DigitalMarketingLegacyWorkspace = {
+  hired_instance_id: string
+  help_visible?: boolean
+  activation_complete?: boolean
+  induction?: {
+    nickname?: string
+    theme?: string
+    primary_language?: string
+    timezone?: string
+    brand_name?: string
+    offerings_services?: string[]
+    location?: string
+    target_audience?: string
+    notes?: string
+  }
+  prepare_agent?: {
+    selected_platforms?: string[]
+    platform_steps?: DigitalMarketingPlatformStep[]
+    all_selected_platforms_completed?: boolean
+  }
+  campaign_setup?: {
+    campaign_id?: string | null
+    master_theme?: string
+    derived_themes?: DigitalMarketingDerivedTheme[]
+    schedule?: Partial<DigitalMarketingCampaignSchedule>
+  }
+  updated_at: string
+}
+
+export type DigitalMarketingThemePlanResponse = {
+  campaign_id?: string | null
+  master_theme: string
+  derived_themes: DigitalMarketingDerivedTheme[]
+  workspace: DigitalMarketingLegacyWorkspace | DigitalMarketingActivationResponse
+}
+
+export type DigitalMarketingActivationWorkspace = {
+  help_visible?: boolean
+  activation_complete?: boolean
+  brand_name?: string
+  location?: string
+  primary_language?: string
+  timezone?: string
+  business_context?: string
+  offerings_services?: string[]
+  platforms_enabled?: string[]
+  selected_platforms?: string[]
+  platform_bindings?: Record<string, DigitalMarketingPlatformBinding>
+  campaign_setup?: DigitalMarketingCampaignSetup
+}
+
+export type DigitalMarketingActivationReadiness = {
+  brief_complete: boolean
+  youtube_selected: boolean
+  youtube_connection_ready: boolean
+  configured: boolean
+  can_finalize: boolean
+  missing_requirements: string[]
+}
+
+export type DigitalMarketingActivationResponse = {
+  hired_instance_id: string
+  customer_id?: string | null
+  agent_type_id: string
+  workspace: DigitalMarketingActivationWorkspace
+  readiness: DigitalMarketingActivationReadiness
+  updated_at: string
+}
+
+export type UpsertDigitalMarketingActivationInput = {
+  workspace: DigitalMarketingActivationWorkspace
+}
+
+export async function getDigitalMarketingActivationWorkspace(
+  hiredInstanceId: string
+): Promise<DigitalMarketingActivationResponse> {
+  const resp = await cpApiClient.get(
+    `/cp/digital-marketing-activation/${encodeURIComponent(hiredInstanceId)}`
+  )
+  return resp.data
+}
+
+export async function upsertDigitalMarketingActivationWorkspace(
+  hiredInstanceId: string,
+  input: UpsertDigitalMarketingActivationInput
+): Promise<DigitalMarketingActivationResponse> {
+  const resp = await cpApiClient.put(
+    `/cp/digital-marketing-activation/${encodeURIComponent(hiredInstanceId)}`,
+    input,
+    { headers: { 'X-Correlation-ID': generateCorrelationId(), 'Content-Type': 'application/json' } }
+  )
+  return resp.data
+}
+
+export async function patchDigitalMarketingActivationWorkspace(
+  hiredInstanceId: string,
+  patch: Record<string, unknown>
+): Promise<DigitalMarketingActivationResponse> {
+  const resp = await cpApiClient.patch(
+    `/cp/digital-marketing-activation/${encodeURIComponent(hiredInstanceId)}`,
+    patch,
+    { headers: { 'X-Correlation-ID': generateCorrelationId(), 'Content-Type': 'application/json' } }
+  )
+  return resp.data
+}
+
+export async function generateDigitalMarketingThemePlan(
+  hiredInstanceId: string,
+  patch: Record<string, unknown> = {}
+): Promise<DigitalMarketingThemePlanResponse> {
+  const resp = await cpApiClient.post(
+    `/cp/digital-marketing-activation/${encodeURIComponent(hiredInstanceId)}/generate-theme-plan`,
+    patch,
+    { headers: { 'X-Correlation-ID': generateCorrelationId(), 'Content-Type': 'application/json' } }
+  )
+  return resp.data
+}

--- a/src/mobile/src/services/marketingReview.service.ts
+++ b/src/mobile/src/services/marketingReview.service.ts
@@ -1,0 +1,153 @@
+import cpApiClient from '@/lib/cpApiClient'
+
+function generateCorrelationId(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}
+
+export type DraftArtifactType = 'text' | 'table' | 'image' | 'audio' | 'video' | 'video_audio'
+
+export type DraftArtifactRequest = {
+  artifact_type: Exclude<DraftArtifactType, 'text'>
+  prompt: string
+  metadata?: Record<string, unknown>
+}
+
+export type GeneratedArtifact = {
+  artifact_type: Exclude<DraftArtifactType, 'text'>
+  uri: string
+  preview_uri?: string | null
+  mime_type?: string | null
+  metadata?: Record<string, unknown>
+}
+
+export type DraftPost = {
+  post_id: string
+  channel: string
+  text: string
+  hashtags?: string[]
+  artifact_type?: DraftArtifactType
+  artifact_uri?: string | null
+  artifact_preview_uri?: string | null
+  artifact_mime_type?: string | null
+  artifact_metadata?: Record<string, unknown>
+  artifact_generation_status?: 'not_requested' | 'queued' | 'running' | 'ready' | 'failed'
+  artifact_job_id?: string | null
+  generated_artifacts?: GeneratedArtifact[]
+  review_status: 'pending_review' | 'approved' | 'changes_requested' | 'rejected'
+  approval_id?: string | null
+  execution_status?: string
+  scheduled_at?: string | null
+  credential_ref?: string | null
+  provider_post_id?: string | null
+  provider_post_url?: string | null
+  publish_ready?: boolean
+  publish_readiness_hint?: string | null
+}
+
+export type DraftBatch = {
+  batch_id: string
+  batch_type?: string
+  parent_batch_id?: string | null
+  agent_id: string
+  hired_instance_id?: string | null
+  customer_id?: string | null
+  theme: string
+  brand_name: string
+  created_at: string
+  status: string
+  posts: DraftPost[]
+}
+
+export type CreateDraftBatchInput = {
+  agent_id: string
+  hired_instance_id?: string | null
+  campaign_id?: string | null
+  batch_type?: string
+  parent_batch_id?: string | null
+  theme: string
+  brand_name: string
+  brief_summary?: string | null
+  offer?: string | null
+  location?: string | null
+  audience?: string | null
+  tone?: string | null
+  language?: string | null
+  youtube_credential_ref?: string | null
+  youtube_visibility?: string
+  public_release_requested?: boolean
+  channels?: string[] | null
+  requested_artifacts?: DraftArtifactRequest[] | null
+}
+
+export type CreateContentFromThemeInput = {
+  youtube_credential_ref?: string | null
+  youtube_visibility?: string
+  public_release_requested?: boolean
+  requested_artifacts?: DraftArtifactRequest[] | null
+}
+
+export type ArtifactStatus = {
+  post_id: string
+  artifact_type: string
+  artifact_generation_status: 'not_requested' | 'queued' | 'running' | 'ready' | 'failed'
+  artifact_uri?: string | null
+  artifact_preview_uri?: string | null
+  artifact_mime_type?: string | null
+  artifact_job_id?: string | null
+}
+
+export async function listCustomerDraftBatches(): Promise<DraftBatch[]> {
+  const resp = await cpApiClient.get('/cp/marketing/draft-batches')
+  return resp.data
+}
+
+export async function createDraftBatch(input: CreateDraftBatchInput): Promise<DraftBatch> {
+  const resp = await cpApiClient.post('/cp/marketing/draft-batches', input, {
+    headers: { 'X-Correlation-ID': generateCorrelationId(), 'Content-Type': 'application/json' },
+  })
+  return resp.data
+}
+
+export async function approveDraftPost(
+  postId: string
+): Promise<{ post_id: string; review_status: string; approval_id: string }> {
+  const resp = await cpApiClient.post(
+    '/cp/marketing/draft-posts/approve',
+    { post_id: postId },
+    { headers: { 'X-Correlation-ID': generateCorrelationId(), 'Content-Type': 'application/json' } }
+  )
+  return resp.data
+}
+
+export async function rejectDraftPost(
+  postId: string,
+  reason?: string
+): Promise<{ post_id: string; decision: string }> {
+  const resp = await cpApiClient.post(
+    '/cp/marketing/draft-posts/reject',
+    { post_id: postId, reason },
+    { headers: { 'X-Correlation-ID': generateCorrelationId(), 'Content-Type': 'application/json' } }
+  )
+  return resp.data
+}
+
+export async function pollDraftPostArtifactStatus(postId: string): Promise<ArtifactStatus> {
+  const resp = await cpApiClient.get(`/cp/marketing/draft-posts/${postId}/artifact-status`)
+  return resp.data
+}
+
+export async function createContentBatchFromTheme(
+  themeBatchId: string,
+  input: CreateContentFromThemeInput
+): Promise<DraftBatch> {
+  const resp = await cpApiClient.post(
+    `/cp/marketing/draft-batches/${themeBatchId}/create-content-batch`,
+    input,
+    { headers: { 'X-Correlation-ID': generateCorrelationId(), 'Content-Type': 'application/json' } }
+  )
+  return resp.data
+}


### PR DESCRIPTION
## MOB-DMA-1 Iteration 1 — Review + Fix

Built on agent branch `copilot/iteration-1-epics-e1-e2-e3-again`.

### What was delivered (by agent)
- **E1-S1** `digitalMarketingActivation.service.ts` — 4 functions (get/upsert/patch/generateThemePlan), X-Correlation-ID on writes, 5 tests
- **E1-S2** `marketingReview.service.ts` — 6 functions mirroring CP service, 4 tests including `rejectDraftPost` with reason
- **E2-S1** `DMAConversationScreen.tsx` — loading/error/empty/chat states, scrollable message bubbles, send button; navigation wired in `types.ts`, `MainNavigator.tsx`, `AgentOperationsScreen.tsx`; 6 tests
- **E2-S2** `ArtifactRenderer.tsx` — image/video/table/queued/failed states; 6 tests
- **E3-S1** VoiceFAB + `useAgentVoiceOverlay` wired as optional toggle; text input always present; 3 tests

### Gaps fixed in this PR
| Gap | Fix |
|---|---|
| `ArtifactRenderer` E2-S2-T3 failing — `testID="artifact-table"` was on `FlatList` (invisible to test renderer) | Moved `testID` to outer `View` wrapper |
| `PlatformConnectionsScreen` missing from `screens/agents/index.ts` (agent stripped it when adding DMAConversationScreen) | Restored export |

### Test results (Docker)
```
Test Suites: 58 passed, 58 total
Tests:       617 passed, 617 total
```
Zero regressions across all 58 suites.