### PR TITLE
fix(ci/terraform): bump waooaw-deploy.yml terraform to 1.10.5 (expired PGP key)

### DIFF
--- a/.github/workflows/waooaw-deploy.yml
+++ b/.github/workflows/waooaw-deploy.yml
@@ -551,7 +551,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.6.0
+          terraform_version: 1.10.5
 
       - name: Terraform fmt check (stacks + modules)
         run: terraform fmt -recursive -check cloud/terraform/stacks cloud/terraform/modules
@@ -701,7 +701,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.6.0
+          terraform_version: 1.10.5
 
       - name: Terraform fmt check (stacks + modules)
         run: terraform fmt -recursive -check cloud/terraform/stacks cloud/terraform/modules


### PR DESCRIPTION
## Problem
The WAOOAW Deploy workflow was pinning `terraform_version: 1.6.0` at two locations (lines 554 and 704). Terraform 1.6.0 embeds an OpenPGP signing key for the HashiCorp provider registry that has since expired. This caused the deploy run to fail with:

```
Error while installing hashicorp/google v5.45.2: error checking signature: openpgp: key expired
```

## Fix
Bump both `terraform_version` entries from `1.6.0` → `1.10.5` (same fix already applied to `waooaw-ci.yml` in PR #1077).

## Testing
No code logic change — only the Terraform binary version used in CI. Verified that Terraform 1.10.5 correctly installs and validates `hashicorp/google v5.45.2` (confirmed in PR #1077 lockfile regeneration).

## Related
- Companion to PR #1077 which fixed `waooaw-ci.yml`
- Addresses failure in https://github.com/dlai-sd/WAOOAW/actions/runs/24653664802