### PR TITLE
fix(mobile/ux): sign-in devnote removal, hire CTA fix, Theme Discovery fix

### DIFF
--- a/src/Plant/BackEnd/api/v1/agent_skills.py
+++ b/src/Plant/BackEnd/api/v1/agent_skills.py
@@ -261,7 +261,6 @@ async def _catalog_skills_fallback(
     result = await db.execute(
         select(AgentCatalogReleaseModel.agent_type_id)
         .where(AgentCatalogReleaseModel.agent_id == agent_id)
-        .where(AgentCatalogReleaseModel.approved_for_new_hire == True)  # noqa: E712
         .limit(1)
     )
     agent_type_id = result.scalar_one_or_none()

--- a/src/mobile/__tests__/agentService.test.ts
+++ b/src/mobile/__tests__/agentService.test.ts
@@ -62,7 +62,7 @@ describe("AgentService", () => {
         allowed_durations: ["monthly"],
         supported_channels: ["youtube"],
         agent_type_id: "type-1",
-        lifecycle_state: "live",
+        lifecycle_state: "live_on_cp",
         approved_for_new_hire: true,
         retired_from_catalog_at: null,
       },
@@ -85,14 +85,14 @@ describe("AgentService", () => {
           ...mockCatalog[0],
           id: "a1",
           industry_name: "marketing",
-          lifecycle_state: "live",
+          lifecycle_state: "live_on_cp",
         },
         {
           ...mockCatalog[0],
           id: "a2",
           public_name: "Edu Agent",
           industry_name: "education",
-          lifecycle_state: "live",
+          lifecycle_state: "live_on_cp",
         },
       ];
       (apiClient.get as jest.Mock).mockResolvedValue({ data: multiCatalog });
@@ -104,7 +104,7 @@ describe("AgentService", () => {
       expect(result[0].industry).toBe("marketing");
     });
 
-    it("should map lifecycle_state=live to status=active", async () => {
+    it("should map lifecycle_state=live_on_cp to status=active", async () => {
       (apiClient.get as jest.Mock).mockResolvedValue({ data: mockCatalog });
 
       const result = await agentService.listAgents();
@@ -136,7 +136,7 @@ describe("AgentService", () => {
         allowed_durations: ["monthly"],
         supported_channels: ["youtube"],
         agent_type_id: "type-1",
-        lifecycle_state: "live",
+        lifecycle_state: "live_on_cp",
         approved_for_new_hire: true,
         retired_from_catalog_at: null,
       };
@@ -170,7 +170,7 @@ describe("AgentService", () => {
         allowed_durations: ["monthly"],
         supported_channels: ["youtube"],
         agent_type_id: "type-1",
-        lifecycle_state: "live",
+        lifecycle_state: "live_on_cp",
         approved_for_new_hire: true,
         retired_from_catalog_at: null,
       },
@@ -186,7 +186,7 @@ describe("AgentService", () => {
         allowed_durations: ["monthly"],
         supported_channels: [],
         agent_type_id: "type-2",
-        lifecycle_state: "live",
+        lifecycle_state: "live_on_cp",
         approved_for_new_hire: true,
         retired_from_catalog_at: null,
       },

--- a/src/mobile/src/components/GoogleSignInButton.tsx
+++ b/src/mobile/src/components/GoogleSignInButton.tsx
@@ -3,16 +3,16 @@
  * Branded button following Google's Sign-In branding guidelines
  */
 
-import React from 'react';
+import React from "react";
 import {
   TouchableOpacity,
   Text,
   StyleSheet,
   ActivityIndicator,
   View,
-} from 'react-native';
-import { Image } from 'expo-image';
-import { useTheme } from '../hooks/useTheme';
+} from "react-native";
+import { Image } from "expo-image";
+import { useTheme } from "../hooks/useTheme";
 
 /**
  * Google Sign In Button Props
@@ -27,7 +27,7 @@ interface GoogleSignInButtonProps {
 
 /**
  * Google Sign In Button
- * 
+ *
  * Follows Google's branding guidelines:
  * - White background
  * - Google logo on left
@@ -45,11 +45,7 @@ export const GoogleSignInButton: React.FC<GoogleSignInButtonProps> = ({
 
   return (
     <TouchableOpacity
-      style={[
-        styles.button,
-        disabled && styles.buttonDisabled,
-        style,
-      ]}
+      style={[styles.button, disabled && styles.buttonDisabled, style]}
       onPress={onPress}
       disabled={disabled || loading}
       activeOpacity={0.8}
@@ -66,7 +62,7 @@ export const GoogleSignInButton: React.FC<GoogleSignInButtonProps> = ({
           <View style={styles.logoContainer}>
             <Text style={styles.googleLogo}>G</Text>
           </View>
-          
+
           {/* Button Text */}
           <Text style={styles.buttonText}>Sign in with Google</Text>
         </View>
@@ -77,18 +73,18 @@ export const GoogleSignInButton: React.FC<GoogleSignInButtonProps> = ({
 
 const styles = StyleSheet.create({
   button: {
-    backgroundColor: '#FFFFFF',
+    backgroundColor: "#FFFFFF",
     borderRadius: 8,
-    paddingVertical: 14,
+    paddingVertical: 10,
     paddingHorizontal: 24,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    minHeight: 52,
-    width: '100%',
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 44,
+    width: "100%",
     maxWidth: 400,
     // Shadow for depth
-    shadowColor: '#000',
+    shadowColor: "#000",
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.1,
     shadowRadius: 4,
@@ -98,26 +94,26 @@ const styles = StyleSheet.create({
     opacity: 0.5,
   },
   content: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
   },
   logoContainer: {
     width: 24,
     height: 24,
     marginRight: 12,
-    alignItems: 'center',
-    justifyContent: 'center',
+    alignItems: "center",
+    justifyContent: "center",
   },
   googleLogo: {
     fontSize: 20,
-    fontWeight: '700',
-    color: '#4285F4',
+    fontWeight: "700",
+    color: "#4285F4",
   },
   buttonText: {
     fontSize: 16,
-    fontWeight: '600',
-    color: '#3C4043',
+    fontWeight: "600",
+    color: "#3C4043",
     letterSpacing: 0.25,
   },
 });

--- a/src/mobile/src/screens/agents/AgentOperationsScreen.tsx
+++ b/src/mobile/src/screens/agents/AgentOperationsScreen.tsx
@@ -5,7 +5,7 @@
  * Accepts optional focusSection param from notification deep-links (E6-S1).
  */
 
-import React, { useRef, useEffect, useState, useCallback } from 'react';
+import React, { useRef, useEffect, useState, useCallback } from "react";
 import {
   View,
   Text,
@@ -15,25 +15,25 @@ import {
   TouchableOpacity,
   ActivityIndicator,
   TextInput,
-} from 'react-native';
-import { useTheme } from '@/hooks/useTheme';
-import { useHiredAgentById, useDeliverables } from '@/hooks/useHiredAgents';
-import { useApprovalQueue } from '@/hooks/useApprovalQueue';
-import { useAgentVoiceOverlay } from '@/hooks/useAgentVoiceOverlay';
-import { ContentDraftApprovalCard } from '@/components/ContentDraftApprovalCard';
-import { ScheduledPostsSection } from '@/components/ScheduledPostsSection';
-import { VoiceFAB } from '@/components/voice/VoiceFAB';
-import apiClient from '@/lib/apiClient';
-import type { MyAgentsStackScreenProps } from '@/navigation/types';
-import { DigitalMarketingBriefStepCard } from '@/components/DigitalMarketingBriefStepCard';
-import { DigitalMarketingBriefSummaryCard } from '@/components/DigitalMarketingBriefSummaryCard';
+} from "react-native";
+import { useTheme } from "@/hooks/useTheme";
+import { useHiredAgentById, useDeliverables } from "@/hooks/useHiredAgents";
+import { useApprovalQueue } from "@/hooks/useApprovalQueue";
+import { useAgentVoiceOverlay } from "@/hooks/useAgentVoiceOverlay";
+import { ContentDraftApprovalCard } from "@/components/ContentDraftApprovalCard";
+import { ScheduledPostsSection } from "@/components/ScheduledPostsSection";
+import { VoiceFAB } from "@/components/voice/VoiceFAB";
+import apiClient from "@/lib/apiClient";
+import type { MyAgentsStackScreenProps } from "@/navigation/types";
+import { DigitalMarketingBriefStepCard } from "@/components/DigitalMarketingBriefStepCard";
+import { DigitalMarketingBriefSummaryCard } from "@/components/DigitalMarketingBriefSummaryCard";
 
-type Props = MyAgentsStackScreenProps<'AgentOperations'>;
+type Props = MyAgentsStackScreenProps<"AgentOperations">;
 
 type GoalSchemaField = {
   key: string;
   label: string;
-  type: 'text' | 'number' | 'boolean' | 'enum' | 'list' | 'object';
+  type: "text" | "number" | "boolean" | "enum" | "list" | "object";
   required?: boolean;
   description?: string;
   options?: string[];
@@ -44,7 +44,7 @@ type AgentSkill = {
   skill_id: string;
   name?: string;
   display_name?: string;
-  skill_name?: string;   // returned by /agents/{id}/skills as Skill.name
+  skill_name?: string; // returned by /agents/{id}/skills as Skill.name
   goal_schema?: { fields?: GoalSchemaField[] };
   goal_config?: Record<string, unknown>;
 };
@@ -57,51 +57,66 @@ type BriefStepDefinition = {
   fieldKeys: string[];
 };
 
-const DIGITAL_MARKETING_AGENT_ID = 'AGT-MKT-DMA-001';
+const DIGITAL_MARKETING_AGENT_ID = "AGT-MKT-DMA-001";
 
 const BRIEF_STEP_DEFINITIONS: BriefStepDefinition[] = [
   {
-    key: 'context',
-    title: 'Map the business context',
-    description: 'Give the agent enough context to sound like your business instead of generic marketing copy.',
-    prompt: 'What business is this agent speaking for, which market are you in, and what locality should shape the examples, language, and proof points?',
-    fieldKeys: ['business_background', 'industry', 'locality'],
+    key: "context",
+    title: "Map the business context",
+    description:
+      "Give the agent enough context to sound like your business instead of generic marketing copy.",
+    prompt:
+      "What business is this agent speaking for, which market are you in, and what locality should shape the examples, language, and proof points?",
+    fieldKeys: ["business_background", "industry", "locality"],
   },
   {
-    key: 'audience',
-    title: 'Define the audience and promise',
-    description: 'Clarify who this content is for and what offer should move them to act.',
-    prompt: 'Who exactly are you trying to reach, what persona should the agent keep in mind, and what offer or promise should the content keep reinforcing?',
-    fieldKeys: ['target_audience', 'persona', 'offer'],
+    key: "audience",
+    title: "Define the audience and promise",
+    description:
+      "Clarify who this content is for and what offer should move them to act.",
+    prompt:
+      "Who exactly are you trying to reach, what persona should the agent keep in mind, and what offer or promise should the content keep reinforcing?",
+    fieldKeys: ["target_audience", "persona", "offer"],
   },
   {
-    key: 'channel',
-    title: 'Shape the YouTube angle',
-    description: 'Translate the business goal into a channel-specific operating brief for YouTube.',
-    prompt: 'What outcome should YouTube drive, what does success look like there, and how often should the agent aim to publish?',
-    fieldKeys: ['objective', 'channel_intent', 'posting_cadence'],
+    key: "channel",
+    title: "Shape the YouTube angle",
+    description:
+      "Translate the business goal into a channel-specific operating brief for YouTube.",
+    prompt:
+      "What outcome should YouTube drive, what does success look like there, and how often should the agent aim to publish?",
+    fieldKeys: ["objective", "channel_intent", "posting_cadence"],
   },
   {
-    key: 'voice',
-    title: 'Lock the voice and proof signal',
-    description: 'Finish with how the work should sound and what signal tells you the brief is working.',
-    prompt: 'What tone should the agent protect in every draft, and which business signals should tell you the content is doing its job?',
-    fieldKeys: ['tone', 'success_metrics'],
+    key: "voice",
+    title: "Lock the voice and proof signal",
+    description:
+      "Finish with how the work should sound and what signal tells you the brief is working.",
+    prompt:
+      "What tone should the agent protect in every draft, and which business signals should tell you the content is doing its job?",
+    fieldKeys: ["tone", "success_metrics"],
   },
 ];
 
 function hasValue(value: unknown): boolean {
   if (Array.isArray(value)) return value.length > 0;
-  if (value && typeof value === 'object') return Object.keys(value as Record<string, unknown>).length > 0;
-  return String(value ?? '').trim().length > 0;
+  if (value && typeof value === "object")
+    return Object.keys(value as Record<string, unknown>).length > 0;
+  return String(value ?? "").trim().length > 0;
 }
 
-function isFieldVisible(field: GoalSchemaField, values: Record<string, unknown>): boolean {
+function isFieldVisible(
+  field: GoalSchemaField,
+  values: Record<string, unknown>,
+): boolean {
   if (!field.show_if) return true;
   return values[field.show_if.key] === field.show_if.value;
 }
 
-function isFieldComplete(field: GoalSchemaField, values: Record<string, unknown>): boolean {
+function isFieldComplete(
+  field: GoalSchemaField,
+  values: Record<string, unknown>,
+): boolean {
   if (!isFieldVisible(field, values)) return true;
   if (!field.required) return true;
   return hasValue(values[field.key]);
@@ -131,10 +146,12 @@ function buildBriefSteps(fields: GoalSchemaField[]) {
       };
     } else {
       steps.push({
-        key: 'brief',
-        title: 'Capture the brief',
-        description: 'Capture the core operating details the agent needs before it can draft.',
-        prompt: 'Complete the structured brief so the agent can create specific, credible content instead of guessing.',
+        key: "brief",
+        title: "Capture the brief",
+        description:
+          "Capture the core operating details the agent needs before it can draft.",
+        prompt:
+          "Complete the structured brief so the agent can create specific, credible content instead of guessing.",
         fieldKeys: extraFields.map((field) => field.key),
         fields: extraFields,
       });
@@ -148,17 +165,28 @@ function getThemeDiscoverySkill(skills: AgentSkill[]): AgentSkill | null {
   return (
     skills.find((skill) => {
       const names = [skill.display_name, skill.name, skill.skill_name]
-        .map((value) => String(value || '').trim().toLowerCase())
+        .map((value) =>
+          String(value || "")
+            .trim()
+            .toLowerCase(),
+        )
         .filter(Boolean);
-      return names.some((value) => value === 'theme discovery' || value === 'theme_discovery');
+      return names.some(
+        (value) => value === "theme discovery" || value === "theme_discovery",
+      );
     }) || null
   );
 }
 
-function isDigitalMarketingAgent(agentId?: string | null, agentTypeId?: string | null): boolean {
+function isDigitalMarketingAgent(
+  agentId?: string | null,
+  agentTypeId?: string | null,
+): boolean {
   return (
-    String(agentId || '').trim().toUpperCase() === DIGITAL_MARKETING_AGENT_ID ||
-    String(agentTypeId || '').trim() === 'marketing.digital_marketing.v1'
+    String(agentId || "")
+      .trim()
+      .toUpperCase() === DIGITAL_MARKETING_AGENT_ID ||
+    String(agentTypeId || "").trim() === "marketing.digital_marketing.v1"
   );
 }
 
@@ -175,9 +203,11 @@ function normalizeSkillsPayload(data: unknown): AgentSkill[] {
 
 function getResumeStepIndex(
   steps: Array<{ fields: GoalSchemaField[] }>,
-  values: Record<string, unknown>
+  values: Record<string, unknown>,
 ): number {
-  const index = steps.findIndex((step) => step.fields.some((field) => !isFieldComplete(field, values)));
+  const index = steps.findIndex((step) =>
+    step.fields.some((field) => !isFieldComplete(field, values)),
+  );
   if (index >= 0) return index;
   return Math.max(steps.length - 1, 0);
 }
@@ -185,17 +215,17 @@ function getResumeStepIndex(
 // ─── Section map ─────────────────────────────────────────────────────────────
 
 const SECTIONS = [
-  { id: 'activity',   title: "Today's Activity",      icon: '⚡' },
-  { id: 'approvals',  title: 'Pending Approvals',      icon: '✋' },
-  { id: 'scheduler',  title: 'Schedule Controls',      icon: '🕐' },
-  { id: 'health',     title: 'Connection Health',      icon: '🔗' },
-  { id: 'goals',      title: 'Goal Configuration',     icon: '🎯' },
-  { id: 'spend',      title: 'Trial Usage & Spend',    icon: '💰' },
-  { id: 'recent',     title: 'Recent Publications',    icon: '📤' },
-  { id: 'history',    title: 'Performance History',    icon: '📈' },
+  { id: "activity", title: "Today's Activity", icon: "⚡" },
+  { id: "approvals", title: "Pending Approvals", icon: "✋" },
+  { id: "scheduler", title: "Schedule Controls", icon: "🕐" },
+  { id: "health", title: "Connection Health", icon: "🔗" },
+  { id: "goals", title: "Goal Configuration", icon: "🎯" },
+  { id: "spend", title: "Trial Usage & Spend", icon: "💰" },
+  { id: "recent", title: "Recent Publications", icon: "📤" },
+  { id: "history", title: "Performance History", icon: "📈" },
 ] as const;
 
-type SectionId = typeof SECTIONS[number]['id'];
+type SectionId = (typeof SECTIONS)[number]["id"];
 
 // ─── Collapsible section card ─────────────────────────────────────────────────
 
@@ -210,37 +240,55 @@ interface SectionCardProps {
 }
 
 const SectionCard = ({
-  id, title, icon, badge, expanded, onToggle, children,
+  id,
+  title,
+  icon,
+  badge,
+  expanded,
+  onToggle,
+  children,
 }: SectionCardProps) => {
   const { colors, spacing, typography } = useTheme();
   return (
     <View
-      style={[sectionStyles.card, { borderColor: colors.textSecondary + '20' }]}
+      style={[sectionStyles.card, { borderColor: colors.textSecondary + "20" }]}
       testID={`agent-ops-section-${id}`}
     >
       <TouchableOpacity
         style={sectionStyles.header}
         onPress={() => onToggle(id)}
         accessibilityRole="button"
-        accessibilityLabel={`${expanded ? 'Collapse' : 'Expand'} ${title}`}
+        accessibilityLabel={`${expanded ? "Collapse" : "Expand"} ${title}`}
       >
         <Text style={sectionStyles.icon}>{icon}</Text>
-        <Text style={[sectionStyles.title, { color: colors.textPrimary,
-          fontFamily: typography.fontFamily.bodyBold }]}>
+        <Text
+          style={[
+            sectionStyles.title,
+            {
+              color: colors.textPrimary,
+              fontFamily: typography.fontFamily.bodyBold,
+            },
+          ]}
+        >
           {title}
         </Text>
         {badge != null && badge > 0 && (
-          <View style={[sectionStyles.badge, { backgroundColor: '#f59e0b44' }]}>
-            <Text style={[sectionStyles.badgeText, { color: '#f59e0b' }]}>{badge}</Text>
+          <View style={[sectionStyles.badge, { backgroundColor: "#f59e0b44" }]}>
+            <Text style={[sectionStyles.badgeText, { color: "#f59e0b" }]}>
+              {badge}
+            </Text>
           </View>
         )}
         <Text style={[sectionStyles.chevron, { color: colors.textSecondary }]}>
-          {expanded ? '▲' : '▼'}
+          {expanded ? "▲" : "▼"}
         </Text>
       </TouchableOpacity>
       {expanded && (
         <View
-          style={[sectionStyles.body, { borderTopColor: colors.textSecondary + '20' }]}
+          style={[
+            sectionStyles.body,
+            { borderTopColor: colors.textSecondary + "20" },
+          ]}
           testID={`agent-ops-section-body-${id}`}
         >
           {children}
@@ -255,12 +303,12 @@ const sectionStyles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: 12,
     marginBottom: 12,
-    overflow: 'hidden',
-    backgroundColor: '#18181b',
+    overflow: "hidden",
+    backgroundColor: "#18181b",
   },
   header: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     padding: 16,
     gap: 10,
   },
@@ -272,7 +320,7 @@ const sectionStyles = StyleSheet.create({
     paddingVertical: 2,
     marginRight: 6,
   },
-  badgeText: { fontSize: 12, fontWeight: '600' },
+  badgeText: { fontSize: 12, fontWeight: "600" },
   chevron: { fontSize: 12 },
   body: { borderTopWidth: 1, padding: 16 },
 });
@@ -286,13 +334,21 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
   const sectionRefs = useRef<Record<string, number>>({});
 
   const { data: agent, isLoading } = useHiredAgentById(hiredAgentId);
-  const { deliverables: pendingApprovals, approve, reject } = useApprovalQueue(hiredAgentId);
+  const {
+    deliverables: pendingApprovals,
+    approve,
+    reject,
+  } = useApprovalQueue(hiredAgentId);
   const { data: allDeliverables = [] } = useDeliverables(hiredAgentId);
 
   // Weekly output count — deliverables created since start of current week
   const weeklyCount = React.useMemo(() => {
     const now = new Date();
-    const startOfWeek = new Date(now.getFullYear(), now.getMonth(), now.getDate() - now.getDay());
+    const startOfWeek = new Date(
+      now.getFullYear(),
+      now.getMonth(),
+      now.getDate() - now.getDay(),
+    );
     startOfWeek.setHours(0, 0, 0, 0);
     return allDeliverables.filter((d) => {
       if (!d.created_at) return false;
@@ -303,7 +359,7 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
   // Expanded sections state — focusSection is pre-expanded on mount
   const [expanded, setExpanded] = useState<Record<SectionId, boolean>>(() => {
     const initial = Object.fromEntries(
-      SECTIONS.map((s) => [s.id, false])
+      SECTIONS.map((s) => [s.id, false]),
     ) as Record<SectionId, boolean>;
     if (focusSection && focusSection in initial) {
       initial[focusSection as SectionId] = true;
@@ -317,21 +373,29 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
   const [briefSaving, setBriefSaving] = useState(false);
   const [briefError, setBriefError] = useState<string | null>(null);
   const [briefSuccess, setBriefSuccess] = useState<string | null>(null);
-  const [themeDiscoveryFields, setThemeDiscoveryFields] = useState<GoalSchemaField[]>([]);
-  const [themeDiscoverySkillId, setThemeDiscoverySkillId] = useState('');
+  const [themeDiscoveryFields, setThemeDiscoveryFields] = useState<
+    GoalSchemaField[]
+  >([]);
+  const [themeDiscoverySkillId, setThemeDiscoverySkillId] = useState("");
   const [briefValues, setBriefValues] = useState<Record<string, unknown>>({});
   const [currentBriefStepIndex, setCurrentBriefStepIndex] = useState(0);
 
-  const isDigitalMarketing = isDigitalMarketingAgent(agent?.agent_id, agent?.agent_type_id);
+  const isDigitalMarketing = isDigitalMarketingAgent(
+    agent?.agent_id,
+    agent?.agent_type_id,
+  );
 
   const briefSteps = React.useMemo(
     () => buildBriefSteps(themeDiscoveryFields),
-    [themeDiscoveryFields]
+    [themeDiscoveryFields],
   );
   const currentBriefStep = briefSteps[currentBriefStepIndex] || null;
   const visibleBriefFields = React.useMemo(
-    () => themeDiscoveryFields.filter((field) => isFieldVisible(field, briefValues)),
-    [themeDiscoveryFields, briefValues]
+    () =>
+      themeDiscoveryFields.filter((field) =>
+        isFieldVisible(field, briefValues),
+      ),
+    [themeDiscoveryFields, briefValues],
   );
   const missingFieldLabels = React.useMemo(() => {
     if (!currentBriefStep) return [];
@@ -354,7 +418,10 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
     // Small delay for layout to complete
     const timer = setTimeout(() => {
       const yOffset = sectionRefs.current[id] ?? 0;
-      if (scrollRef.current && typeof (scrollRef.current as any).scrollTo === 'function') {
+      if (
+        scrollRef.current &&
+        typeof (scrollRef.current as any).scrollTo === "function"
+      ) {
         (scrollRef.current as any).scrollTo({ y: yOffset, animated: true });
       }
     }, 300);
@@ -367,7 +434,7 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
     const loadThemeDiscovery = async () => {
       if (!isDigitalMarketing) {
         setThemeDiscoveryFields([]);
-        setThemeDiscoverySkillId('');
+        setThemeDiscoverySkillId("");
         setBriefValues({});
         setBriefError(null);
         setBriefSuccess(null);
@@ -382,21 +449,25 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
         const agentId = agent?.agent_id;
         if (!agentId) {
           if (!cancelled) {
-            setBriefError('Agent details not loaded yet. Please try again.');
+            setBriefError("Agent details not loaded yet. Please try again.");
             setBriefLoading(false);
           }
           return;
         }
-        const response = await apiClient.get(`/api/v1/agents/${agentId}/skills`);
+        const response = await apiClient.get(
+          `/api/v1/agents/${agentId}/skills`,
+        );
         const skills = normalizeSkillsPayload(response.data);
         const skill = getThemeDiscoverySkill(skills);
         if (!skill) {
           if (!cancelled) {
             setThemeDiscoveryFields([]);
-            setThemeDiscoverySkillId('');
+            setThemeDiscoverySkillId("");
             setBriefValues({});
             setCurrentBriefStepIndex(0);
-            setBriefError('This hired agent does not expose the Theme Discovery skill yet.');
+            setBriefError(
+              "This hired agent does not expose the Theme Discovery skill yet.",
+            );
           }
           return;
         }
@@ -407,15 +478,19 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
           setThemeDiscoveryFields(fields);
           setThemeDiscoverySkillId(skill.skill_id);
           setBriefValues(values);
-          setCurrentBriefStepIndex(getResumeStepIndex(buildBriefSteps(fields), values));
+          setCurrentBriefStepIndex(
+            getResumeStepIndex(buildBriefSteps(fields), values),
+          );
         }
       } catch (error: any) {
         if (!cancelled) {
           setThemeDiscoveryFields([]);
-          setThemeDiscoverySkillId('');
+          setThemeDiscoverySkillId("");
           setBriefValues({});
           setCurrentBriefStepIndex(0);
-          setBriefError(error?.message || 'Failed to load Theme Discovery brief');
+          setBriefError(
+            error?.message || "Failed to load Theme Discovery brief",
+          );
         }
       } finally {
         if (!cancelled) setBriefLoading(false);
@@ -461,14 +536,18 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
     try {
       const response = await apiClient.patch(
         `/api/v1/hired-agents/${hiredAgentId}/skills/${themeDiscoverySkillId}/customer-config`,
-        { customer_fields: briefValues }
+        { customer_fields: briefValues },
       );
-      const nextValues = (response.data as { goal_config?: Record<string, unknown> } | null)?.goal_config || briefValues;
+      const nextValues =
+        (response.data as { goal_config?: Record<string, unknown> } | null)
+          ?.goal_config || briefValues;
       setBriefValues(nextValues);
       setCurrentBriefStepIndex(getResumeStepIndex(briefSteps, nextValues));
-      setBriefSuccess('Theme Discovery brief saved. Content Creation will use this structured brief.');
+      setBriefSuccess(
+        "Theme Discovery brief saved. Content Creation will use this structured brief.",
+      );
     } catch (error: any) {
-      setBriefError(error?.message || 'Failed to save Theme Discovery brief');
+      setBriefError(error?.message || "Failed to save Theme Discovery brief");
     } finally {
       setBriefSaving(false);
     }
@@ -476,35 +555,77 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
 
   const agentName = agent?.nickname || agent?.agent_id || hiredAgentId;
 
-  const { isListening: voiceListening, toggle: voiceToggle, isAvailable: voiceAvailable } =
-    useAgentVoiceOverlay({
-      'go to inbox': () => navigation.navigate('Inbox'),
-      'go to analytics': () => navigation.navigate('ContentAnalytics', { hiredAgentId }),
-      'go to connections': () => navigation.navigate('PlatformConnections', { hiredAgentId }),
-    });
+  const {
+    isListening: voiceListening,
+    toggle: voiceToggle,
+    isAvailable: voiceAvailable,
+  } = useAgentVoiceOverlay({
+    "go to inbox": () => navigation.navigate("Inbox"),
+    "go to analytics": () =>
+      navigation.navigate("ContentAnalytics", { hiredAgentId }),
+    "go to connections": () =>
+      navigation.navigate("PlatformConnections", { hiredAgentId }),
+  });
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: colors.black }} testID="mobile-agent-operations-screen">
+    <SafeAreaView
+      style={{ flex: 1, backgroundColor: colors.black }}
+      testID="mobile-agent-operations-screen"
+    >
       {/* Header */}
-      <View style={{ paddingHorizontal: spacing.screenPadding?.horizontal ?? 16,
-        paddingTop: spacing.md, paddingBottom: spacing.sm }}>
-        <TouchableOpacity onPress={() => navigation.goBack()} style={{ marginBottom: spacing.sm }}>
-          <Text style={{ color: colors.neonCyan,
-            fontFamily: typography.fontFamily.body, fontSize: 14 }}>← Back</Text>
+      <View
+        style={{
+          paddingHorizontal: spacing.screenPadding?.horizontal ?? 16,
+          paddingTop: spacing.md,
+          paddingBottom: spacing.sm,
+        }}
+      >
+        <TouchableOpacity
+          onPress={() => navigation.goBack()}
+          style={{ marginBottom: spacing.sm }}
+        >
+          <Text
+            style={{
+              color: colors.neonCyan,
+              fontFamily: typography.fontFamily.body,
+              fontSize: 14,
+            }}
+          >
+            ← Back
+          </Text>
         </TouchableOpacity>
-        <Text style={{ color: colors.textPrimary,
-          fontFamily: typography.fontFamily.display, fontSize: 22, fontWeight: 'bold' }}>
+        <Text
+          style={{
+            color: colors.textPrimary,
+            fontFamily: typography.fontFamily.display,
+            fontSize: 22,
+            fontWeight: "bold",
+          }}
+        >
           {agentName}
         </Text>
-        <Text style={{ color: colors.textSecondary,
-          fontFamily: typography.fontFamily.body, fontSize: 13, marginTop: 2 }}>
+        <Text
+          style={{
+            color: colors.textSecondary,
+            fontFamily: typography.fontFamily.body,
+            fontSize: 13,
+            marginTop: 2,
+          }}
+        >
           Agent Operations Hub
         </Text>
-        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 12 }}>
+        <View
+          style={{
+            flexDirection: "row",
+            flexWrap: "wrap",
+            gap: 8,
+            marginTop: 12,
+          }}
+        >
           {[
             `${pendingApprovals.length} approvals`,
-            'Scheduler controls',
-            'Health + spend view',
+            "Scheduler controls",
+            "Health + spend view",
           ].map((pill) => (
             <View
               key={pill}
@@ -513,11 +634,13 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
                 paddingVertical: 6,
                 borderRadius: 999,
                 borderWidth: 1,
-                borderColor: colors.textSecondary + '25',
+                borderColor: colors.textSecondary + "25",
                 backgroundColor: colors.card,
               }}
             >
-              <Text style={{ color: colors.textPrimary, fontSize: 12 }}>{pill}</Text>
+              <Text style={{ color: colors.textPrimary, fontSize: 12 }}>
+                {pill}
+              </Text>
             </View>
           ))}
         </View>
@@ -530,48 +653,85 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
             paddingVertical: 10,
             borderRadius: 12,
             borderWidth: 1,
-            borderColor: colors.neonCyan + '30',
+            borderColor: colors.neonCyan + "30",
             backgroundColor: colors.card,
-            flexDirection: 'row',
-            alignItems: 'center',
+            flexDirection: "row",
+            alignItems: "center",
             gap: 8,
           }}
         >
-          <Text style={{ color: colors.neonCyan, fontSize: 20, fontFamily: typography.fontFamily.display, fontWeight: 'bold' }}>
+          <Text
+            style={{
+              color: colors.neonCyan,
+              fontSize: 20,
+              fontFamily: typography.fontFamily.display,
+              fontWeight: "bold",
+            }}
+          >
             {weeklyCount}
           </Text>
-          <Text style={{ color: colors.textSecondary, fontSize: 12, fontFamily: typography.fontFamily.body }}>
-            deliverable{weeklyCount !== 1 ? 's' : ''} this week
+          <Text
+            style={{
+              color: colors.textSecondary,
+              fontSize: 12,
+              fontFamily: typography.fontFamily.body,
+            }}
+          >
+            deliverable{weeklyCount !== 1 ? "s" : ""} this week
           </Text>
         </View>
       </View>
 
       {isLoading ? (
-        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <View
+          style={{ flex: 1, justifyContent: "center", alignItems: "center" }}
+        >
           <ActivityIndicator color={colors.neonCyan} />
         </View>
       ) : (
         <ScrollView
           ref={scrollRef}
-          contentContainerStyle={{ padding: spacing.screenPadding?.horizontal ?? 16,
-            paddingBottom: 40 }}
+          contentContainerStyle={{
+            padding: spacing.screenPadding?.horizontal ?? 16,
+            paddingBottom: 40,
+          }}
         >
           <View
             style={{
               marginBottom: 14,
               borderRadius: 16,
               borderWidth: 1,
-              borderColor: colors.textSecondary + '20',
+              borderColor: colors.textSecondary + "20",
               backgroundColor: colors.card,
               padding: 16,
             }}
           >
-            <Text style={{ color: colors.neonCyan, fontSize: 12, marginBottom: 6 }}>Next best action</Text>
-            <Text style={{ color: colors.textPrimary, fontSize: 16, fontFamily: typography.fontFamily.bodyBold, marginBottom: 4 }}>
-              {pendingApprovals.length > 0 ? 'Clear pending approvals to keep work moving.' : 'Your agent is clear to run. Tune goals or schedule next.'}
+            <Text
+              style={{ color: colors.neonCyan, fontSize: 12, marginBottom: 6 }}
+            >
+              Next best action
             </Text>
-            <Text style={{ color: colors.textSecondary, fontSize: 13, fontFamily: typography.fontFamily.body }}>
-              Mobile should help you make the few decisions only you need to make, fast.
+            <Text
+              style={{
+                color: colors.textPrimary,
+                fontSize: 16,
+                fontFamily: typography.fontFamily.bodyBold,
+                marginBottom: 4,
+              }}
+            >
+              {pendingApprovals.length > 0
+                ? "Clear pending approvals to keep work moving."
+                : "Your agent is clear to run. Tune goals or schedule next."}
+            </Text>
+            <Text
+              style={{
+                color: colors.textSecondary,
+                fontSize: 13,
+                fontFamily: typography.fontFamily.body,
+              }}
+            >
+              Mobile should help you make the few decisions only you need to
+              make, fast.
             </Text>
           </View>
 
@@ -586,15 +746,23 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
                 id={section.id}
                 title={section.title}
                 icon={section.icon}
-                badge={section.id === 'approvals' ? pendingApprovals.length : undefined}
+                badge={
+                  section.id === "approvals"
+                    ? pendingApprovals.length
+                    : undefined
+                }
                 expanded={expanded[section.id]}
                 onToggle={toggleSection}
               >
-                {section.id === 'approvals' && (
+                {section.id === "approvals" && (
                   <View>
                     {pendingApprovals.length === 0 ? (
-                      <Text style={{ color: colors.textSecondary,
-                        fontFamily: typography.fontFamily.body }}>
+                      <Text
+                        style={{
+                          color: colors.textSecondary,
+                          fontFamily: typography.fontFamily.body,
+                        }}
+                      >
                         No pending approvals
                       </Text>
                     ) : (
@@ -610,62 +778,93 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
                   </View>
                 )}
 
-                {section.id === 'scheduler' && (
+                {section.id === "scheduler" && (
                   <View>
-                    <Text style={{ color: colors.textSecondary,
-                      fontFamily: typography.fontFamily.body, marginBottom: 12 }}>
+                    <Text
+                      style={{
+                        color: colors.textSecondary,
+                        fontFamily: typography.fontFamily.body,
+                        marginBottom: 12,
+                      }}
+                    >
                       Manage your agent's execution schedule.
                     </Text>
-                    <View style={{ flexDirection: 'row', gap: 12 }}>
-                      {agent?.subscription_status === 'active' ? (
+                    <View style={{ flexDirection: "row", gap: 12 }}>
+                      {agent?.subscription_status === "active" ? (
                         <TouchableOpacity
-                          style={[styles.actionBtn, { backgroundColor: '#f59e0b22' }]}
+                          style={[
+                            styles.actionBtn,
+                            { backgroundColor: "#f59e0b22" },
+                          ]}
                           onPress={handlePause}
                           disabled={pauseLoading}
                           accessibilityLabel="Pause agent"
                           testID="ops-pause-btn"
                         >
-                          {pauseLoading
-                            ? <ActivityIndicator size="small" color="#f59e0b" />
-                            : <Text style={{ color: '#f59e0b', fontSize: 13 }}>⏸ Pause</Text>}
+                          {pauseLoading ? (
+                            <ActivityIndicator size="small" color="#f59e0b" />
+                          ) : (
+                            <Text style={{ color: "#f59e0b", fontSize: 13 }}>
+                              ⏸ Pause
+                            </Text>
+                          )}
                         </TouchableOpacity>
                       ) : (
                         <TouchableOpacity
-                          style={[styles.actionBtn, { backgroundColor: '#10b98122' }]}
+                          style={[
+                            styles.actionBtn,
+                            { backgroundColor: "#10b98122" },
+                          ]}
                           onPress={handleResume}
                           disabled={resumeLoading}
                           accessibilityLabel="Resume agent"
                           testID="ops-resume-btn"
                         >
-                          {resumeLoading
-                            ? <ActivityIndicator size="small" color="#10b981" />
-                            : <Text style={{ color: '#10b981', fontSize: 13 }}>▶ Resume</Text>}
+                          {resumeLoading ? (
+                            <ActivityIndicator size="small" color="#10b981" />
+                          ) : (
+                            <Text style={{ color: "#10b981", fontSize: 13 }}>
+                              ▶ Resume
+                            </Text>
+                          )}
                         </TouchableOpacity>
                       )}
                     </View>
                     <ScheduledPostsSection hiredAgentId={hiredAgentId} />
                     <TouchableOpacity
                       testID="ops-see-all-posts"
-                      onPress={() => navigation.navigate('ScheduledPosts', { hiredAgentId })}
-                      style={{ marginTop: 8, alignSelf: 'flex-end' }}
+                      onPress={() =>
+                        navigation.navigate("ScheduledPosts", { hiredAgentId })
+                      }
+                      style={{ marginTop: 8, alignSelf: "flex-end" }}
                     >
-                      <Text style={{ color: colors.neonCyan, fontSize: 13 }}>See all posts →</Text>
+                      <Text style={{ color: colors.neonCyan, fontSize: 13 }}>
+                        See all posts →
+                      </Text>
                     </TouchableOpacity>
                   </View>
                 )}
 
-                {section.id === 'goals' && isDigitalMarketing && (
+                {section.id === "goals" && isDigitalMarketing && (
                   <View style={{ gap: 12 }}>
                     <View
                       style={{
                         borderRadius: 12,
                         borderWidth: 1,
-                        borderColor: colors.textSecondary + '20',
+                        borderColor: colors.textSecondary + "20",
                         backgroundColor: colors.card,
                         padding: 12,
                       }}
                     >
-                      <Text style={{ color: colors.neonCyan, fontSize: 12, marginBottom: 4 }}>Theme Discovery</Text>
+                      <Text
+                        style={{
+                          color: colors.neonCyan,
+                          fontSize: 12,
+                          marginBottom: 4,
+                        }}
+                      >
+                        Theme Discovery
+                      </Text>
                       <Text
                         style={{
                           color: colors.textPrimary,
@@ -676,26 +875,65 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
                       >
                         Keep the brief continuous across CP and mobile.
                       </Text>
-                      <Text style={{ color: colors.textSecondary, fontFamily: typography.fontFamily.body, fontSize: 13 }}>
-                        This mobile flow resumes the same structured brief the Digital Marketing Agent uses for draft generation and YouTube readiness.
+                      <Text
+                        style={{
+                          color: colors.textSecondary,
+                          fontFamily: typography.fontFamily.body,
+                          fontSize: 13,
+                        }}
+                      >
+                        This mobile flow resumes the same structured brief the
+                        Digital Marketing Agent uses for draft generation and
+                        YouTube readiness.
                       </Text>
                     </View>
 
                     {briefLoading ? (
-                      <View style={[styles.infoCard, { borderColor: colors.textSecondary + '20' }]}>
+                      <View
+                        style={[
+                          styles.infoCard,
+                          { borderColor: colors.textSecondary + "20" },
+                        ]}
+                      >
                         <ActivityIndicator color={colors.neonCyan} />
-                        <Text style={{ color: colors.textSecondary, fontFamily: typography.fontFamily.body }}>
+                        <Text
+                          style={{
+                            color: colors.textSecondary,
+                            fontFamily: typography.fontFamily.body,
+                          }}
+                        >
                           Loading Theme Discovery brief...
                         </Text>
                       </View>
                     ) : null}
 
                     {briefError ? (
-                      <View style={[styles.infoCard, { borderColor: '#ef444455', backgroundColor: '#ef444418' }]}>
-                        <Text style={{ color: '#ef4444', fontFamily: typography.fontFamily.bodyBold, marginBottom: 4 }}>
+                      <View
+                        style={[
+                          styles.infoCard,
+                          {
+                            borderColor: "#ef444455",
+                            backgroundColor: "#ef444418",
+                          },
+                        ]}
+                      >
+                        <Text
+                          style={{
+                            color: "#ef4444",
+                            fontFamily: typography.fontFamily.bodyBold,
+                            marginBottom: 4,
+                          }}
+                        >
                           Theme Discovery unavailable
                         </Text>
-                        <Text style={{ color: colors.textPrimary, fontFamily: typography.fontFamily.body }}>{briefError}</Text>
+                        <Text
+                          style={{
+                            color: colors.textPrimary,
+                            fontFamily: typography.fontFamily.body,
+                          }}
+                        >
+                          {briefError}
+                        </Text>
                       </View>
                     ) : null}
 
@@ -712,11 +950,21 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
                           canGoBack={currentBriefStepIndex > 0}
                           canContinue={canContinueBrief}
                           isSaving={briefSaving}
-                          isLastStep={currentBriefStepIndex === briefSteps.length - 1}
+                          isLastStep={
+                            currentBriefStepIndex === briefSteps.length - 1
+                          }
                           missingFieldLabels={missingFieldLabels}
                           onChange={handleBriefFieldChange}
-                          onBack={() => setCurrentBriefStepIndex((index) => Math.max(0, index - 1))}
-                          onNext={() => setCurrentBriefStepIndex((index) => Math.min(briefSteps.length - 1, index + 1))}
+                          onBack={() =>
+                            setCurrentBriefStepIndex((index) =>
+                              Math.max(0, index - 1),
+                            )
+                          }
+                          onNext={() =>
+                            setCurrentBriefStepIndex((index) =>
+                              Math.min(briefSteps.length - 1, index + 1),
+                            )
+                          }
                           onSave={handleBriefSave}
                         />
 
@@ -725,21 +973,32 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
                             style={[
                               styles.infoCard,
                               {
-                                borderColor: briefError ? '#ef444455' : '#10b98155',
-                                backgroundColor: briefError ? '#ef444418' : '#10b98118',
+                                borderColor: briefError
+                                  ? "#ef444455"
+                                  : "#10b98155",
+                                backgroundColor: briefError
+                                  ? "#ef444418"
+                                  : "#10b98118",
                               },
                             ]}
                           >
                             <Text
                               style={{
-                                color: briefError ? '#ef4444' : '#10b981',
+                                color: briefError ? "#ef4444" : "#10b981",
                                 fontFamily: typography.fontFamily.bodyBold,
                                 marginBottom: 4,
                               }}
                             >
-                              {briefError ? 'Theme Discovery was not saved' : 'Theme Discovery saved'}
+                              {briefError
+                                ? "Theme Discovery was not saved"
+                                : "Theme Discovery saved"}
                             </Text>
-                            <Text style={{ color: colors.textPrimary, fontFamily: typography.fontFamily.body }}>
+                            <Text
+                              style={{
+                                color: colors.textPrimary,
+                                fontFamily: typography.fontFamily.body,
+                              }}
+                            >
                               {briefError || briefSuccess}
                             </Text>
                           </View>
@@ -750,12 +1009,28 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
                           values={briefValues}
                         />
                         <TouchableOpacity
-                          style={[styles.actionBtn, { backgroundColor: colors.neonCyan + '22', marginTop: 12 }]}
-                          onPress={() => navigation.navigate('DMAConversation', { hiredAgentId })}
+                          style={[
+                            styles.actionBtn,
+                            {
+                              backgroundColor: colors.neonCyan + "22",
+                              marginTop: 12,
+                            },
+                          ]}
+                          onPress={() =>
+                            navigation.navigate("DMAConversation", {
+                              hiredAgentId,
+                            })
+                          }
                           testID="chat-with-agent-btn"
                           accessibilityLabel="Chat with Agent"
                         >
-                          <Text style={{ color: colors.neonCyan, fontSize: 14, fontWeight: '600' }}>
+                          <Text
+                            style={{
+                              color: colors.neonCyan,
+                              fontSize: 14,
+                              fontWeight: "600",
+                            }}
+                          >
                             💬 Chat with Agent
                           </Text>
                         </TouchableOpacity>
@@ -764,12 +1039,18 @@ export const AgentOperationsScreen = ({ navigation, route }: Props) => {
                   </View>
                 )}
 
-                {section.id !== 'approvals' && section.id !== 'scheduler' && !(section.id === 'goals' && isDigitalMarketing) && (
-                  <Text style={{ color: colors.textSecondary,
-                    fontFamily: typography.fontFamily.body }}>
-                    {section.title} data will appear here.
-                  </Text>
-                )}
+                {section.id !== "approvals" &&
+                  section.id !== "scheduler" &&
+                  !(section.id === "goals" && isDigitalMarketing) && (
+                    <Text
+                      style={{
+                        color: colors.textSecondary,
+                        fontFamily: typography.fontFamily.body,
+                      }}
+                    >
+                      {section.title} data will appear here.
+                    </Text>
+                  )}
               </SectionCard>
             </View>
           ))}
@@ -798,13 +1079,13 @@ const styles = StyleSheet.create({
   approvalItem: {
     paddingVertical: 10,
     borderBottomWidth: 1,
-    borderBottomColor: '#27272a',
+    borderBottomColor: "#27272a",
   },
   actionBtn: {
     borderRadius: 8,
     paddingHorizontal: 14,
     paddingVertical: 7,
-    alignItems: 'center',
-    justifyContent: 'center',
+    alignItems: "center",
+    justifyContent: "center",
   },
 });

--- a/src/mobile/src/screens/auth/SignInScreen.tsx
+++ b/src/mobile/src/screens/auth/SignInScreen.tsx
@@ -18,7 +18,7 @@ import { Image } from "expo-image";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { GoogleSignInButton } from "../../components/GoogleSignInButton";
 import { useGoogleAuth } from "../../hooks/useGoogleAuth";
-import * as AppleAuthentication from 'expo-apple-authentication';
+import * as AppleAuthentication from "expo-apple-authentication";
 import AuthService from "../../services/auth.service";
 import userDataService from "../../services/userDataService";
 import { useTheme } from "../../hooks/useTheme";
@@ -71,9 +71,9 @@ export const SignInScreen: React.FC<SignInScreenProps> = ({
       await signInWithApple();
       if (onSignInSuccess) onSignInSuccess();
     } catch (error: any) {
-      if (error?.code !== 'ERR_REQUEST_CANCELED') {
-        console.error('Apple sign-in failed:', error);
-        setErrorMessage('Apple sign-in failed. Please try again.');
+      if (error?.code !== "ERR_REQUEST_CANCELED") {
+        console.error("Apple sign-in failed:", error);
+        setErrorMessage("Apple sign-in failed. Please try again.");
       }
     } finally {
       setIsSigningIn(false);
@@ -120,9 +120,14 @@ export const SignInScreen: React.FC<SignInScreenProps> = ({
 
         // Persist to AsyncStorage for next app start — fire-and-forget so
         // navigation to the dashboard is not blocked by storage write latency.
-        userDataService.saveUserData(authUser).catch((e) =>
-          console.warn('[SignInScreen] saveUserData failed (non-blocking):', e)
-        );
+        userDataService
+          .saveUserData(authUser)
+          .catch((e) =>
+            console.warn(
+              "[SignInScreen] saveUserData failed (non-blocking):",
+              e,
+            ),
+          );
 
         // Navigate to main app
         if (onSignInSuccess) {
@@ -240,17 +245,26 @@ export const SignInScreen: React.FC<SignInScreenProps> = ({
                   color: colors.textSecondary,
                   fontFamily: typography.fontFamily.body,
                   fontSize: 14,
-                  textAlign: 'center',
+                  textAlign: "center",
                   marginTop: spacing.md,
                   maxWidth: 320,
                   lineHeight: 20,
                 }}
               >
-                Use mobile as your fastest decision surface for approvals, spend awareness, and agent operations.
+                Use mobile as your fastest decision surface for approvals, spend
+                awareness, and agent operations.
               </Text>
 
-              <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: spacing.md, justifyContent: 'center' }}>
-                {['1-tap sign in', 'Customer-safe', 'Ops-ready'].map((pill) => (
+              <View
+                style={{
+                  flexDirection: "row",
+                  flexWrap: "wrap",
+                  gap: 8,
+                  marginTop: spacing.md,
+                  justifyContent: "center",
+                }}
+              >
+                {["1-tap sign in", "Customer-safe", "Ops-ready"].map((pill) => (
                   <View
                     key={pill}
                     style={{
@@ -258,11 +272,19 @@ export const SignInScreen: React.FC<SignInScreenProps> = ({
                       paddingVertical: 6,
                       borderRadius: 999,
                       borderWidth: 1,
-                      borderColor: colors.textSecondary + '25',
+                      borderColor: colors.textSecondary + "25",
                       backgroundColor: colors.card,
                     }}
                   >
-                    <Text style={{ color: colors.textPrimary, fontSize: 12, fontFamily: typography.fontFamily.bodyBold }}>{pill}</Text>
+                    <Text
+                      style={{
+                        color: colors.textPrimary,
+                        fontSize: 12,
+                        fontFamily: typography.fontFamily.bodyBold,
+                      }}
+                    >
+                      {pill}
+                    </Text>
                   </View>
                 ))}
               </View>
@@ -270,28 +292,6 @@ export const SignInScreen: React.FC<SignInScreenProps> = ({
 
             {/* Sign In Button Section */}
             <View style={[styles.buttonSection, { marginTop: spacing.xxl }]}>
-              <View
-                style={{
-                  width: '100%',
-                  borderRadius: 16,
-                  padding: spacing.lg,
-                  borderWidth: 1,
-                  borderColor: colors.textSecondary + '20',
-                  backgroundColor: colors.card,
-                  marginBottom: spacing.lg,
-                }}
-              >
-                <Text style={{ color: colors.neonCyan, fontSize: 12, marginBottom: 6, fontFamily: typography.fontFamily.bodyBold }}>
-                  Why this screen matters
-                </Text>
-                <Text style={{ color: colors.textPrimary, fontSize: 15, fontFamily: typography.fontFamily.bodyBold, marginBottom: 4 }}>
-                  Customers should feel oriented, not dumped into OAuth.
-                </Text>
-                <Text style={{ color: colors.textSecondary, fontSize: 13, fontFamily: typography.fontFamily.body }}>
-                  Sign in is the front door to hiring, approvals, billing visibility, and profile control.
-                </Text>
-              </View>
-
               <GoogleSignInButton
                 onPress={handleGoogleSignIn}
                 loading={isLoading}
@@ -300,12 +300,16 @@ export const SignInScreen: React.FC<SignInScreenProps> = ({
               />
 
               {/* Apple Sign-In (iOS only) */}
-              {Platform.OS === 'ios' && (
+              {Platform.OS === "ios" && (
                 <AppleAuthentication.AppleAuthenticationButton
-                  buttonType={AppleAuthentication.AppleAuthenticationButtonType.SIGN_IN}
-                  buttonStyle={AppleAuthentication.AppleAuthenticationButtonStyle.BLACK}
+                  buttonType={
+                    AppleAuthentication.AppleAuthenticationButtonType.SIGN_IN
+                  }
+                  buttonStyle={
+                    AppleAuthentication.AppleAuthenticationButtonStyle.BLACK
+                  }
                   cornerRadius={12}
-                  style={{ width: '100%', height: 44, marginTop: 12 }}
+                  style={{ width: "100%", height: 44, marginTop: 12 }}
                   onPress={handleAppleSignIn}
                 />
               )}

--- a/src/mobile/src/services/agents/agent.service.ts
+++ b/src/mobile/src/services/agents/agent.service.ts
@@ -47,7 +47,7 @@ function catalogToAgent(c: CatalogAgentResponse): Agent {
     industry: (c.industry_name || "").toLowerCase() as Agent["industry"],
     job_role_id: "", // not in catalog; not used by AgentCard
     entity_type: "agent",
-    status: c.lifecycle_state === "live" ? "active" : "inactive",
+    status: c.lifecycle_state === "live_on_cp" ? "active" : "inactive",
     specialization: c.job_role_label,
     price: c.monthly_price_inr,
     trial_days: c.trial_days,


### PR DESCRIPTION
## Changes

### Issue 1 — Sign In devnote box removed + button slimmed
**Root cause**: `SignInScreen.tsx` had a development annotation View block rendering 'Why this screen matters' / 'Customers should feel oriented' text. `GoogleSignInButton` had `paddingVertical: 14, minHeight: 52` making it very tall.
**Fix**: Removed the dev annotation block; reduced button to `paddingVertical: 10, minHeight: 44`.

### Issue 2 — Agent detail 'Currently Unavailable' blocking hire CTA
**Root cause**: `catalogToAgent()` in `agent.service.ts` checked `lifecycle_state === 'live'` but the DB value for published agents is `'live_on_cp'`. Every agent always mapped to `status: 'inactive'` → 'Currently Unavailable' shown, 'Start 7-Day Free Trial' CTA hidden.
**Fix**: `lifecycle_state === 'live_on_cp'` is the correct check.

### Issue 3 — 'Theme Discovery unavailable' on Ops screen
**Root cause**: `_catalog_skills_fallback()` in `agent_skills.py` queried `approved_for_new_hire == True`. For the demo DB the DMA agent has `approved_for_new_hire = False` (default until a publish API call). This caused a 404 → mobile showed unavailable error. The skills endpoint is used from the Ops screen for already-hired agents; the hire-gate flag should not block skills discovery.
**Fix**: Removed `approved_for_new_hire == True` constraint from the fallback query.

## Testing
- Plant backend: 1739 passed (11 pre-existing DB-dependent failures unchanged)
- Mobile Prettier: all changed files formatted
- `agentService.test.ts`: mocks updated to `lifecycle_state: 'live_on_cp'`