### PR TITLE
chore(dx): fix prompt file frontmatter mode: → agent: (VS Code Copilot spec)

### DIFF
--- a/.github/prompts/get-plan.prompt.md
+++ b/.github/prompts/get-plan.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: agent
+agent: agent
 description: Create a self-sufficient, agent-executable iteration plan from a product vision
 ---
 

--- a/.github/prompts/get-ready.prompt.md
+++ b/.github/prompts/get-ready.prompt.md
@@ -1,5 +1,5 @@
 ---
-mode: agent
+agent: agent
 description: Bootstrap agent with full WAOOAW platform context before starting any task
 ---
 


### PR DESCRIPTION
Fixes /get-ready and /get-plan slash commands which stopped appearing in VS Code Copilot Chat after the extension updated its frontmatter spec from `mode: agent` to `agent: agent`.

**Changed files:**
- `.github/prompts/get-ready.prompt.md`
- `.github/prompts/get-plan.prompt.md`

No application code changes. CI should pass unchanged.