### PR TITLE
fix(share-trader): use Delta Exchange India URL for all API calls

### DIFF
--- a/src/Plant/BackEnd/api/v1/exchange_credentials.py
+++ b/src/Plant/BackEnd/api/v1/exchange_credentials.py
@@ -163,17 +163,17 @@ async def validate_exchange_credential(
 
 @circuit_breaker(service="delta_exchange_api")
 async def _validate_exchange_live(
-    *, api_key: str, api_secret: str
+    *, api_key: str, api_secret: str, exchange_provider: str = "delta_exchange_india"
 ) -> tuple[bool, bool, dict, Optional[str]]:
     """Live Delta Exchange credential check. Returns (readable, tradeable, balance_summary, error).
 
-    Mock is active in test/development/local environments unless
-    DELTA_EXCHANGE_REAL_API=true is set (Codespace/demo opt-in).
+    Mock is active in test/development/local unless DELTA_EXCHANGE_REAL_API=true.
 
-    In real mode: two HMAC-signed calls are made —
-      1. GET /v2/wallet/balances  — confirms read access (api_key is valid)
-      2. GET /v2/profile          — confirms the key is active and retrievable
-    api_key and api_secret are NEVER logged.
+    IMPORTANT — provider-specific base URL:
+      delta_exchange_india  → https://api.india.delta.exchange
+      delta_exchange        → https://api.delta.exchange
+    These are SEPARATE platforms with separate accounts. India keys will return
+    401 invalid_api_key on the international URL and vice versa.
     """
     import os
     env = settings.environment
@@ -182,24 +182,27 @@ async def _validate_exchange_live(
     if env in mock_envs and not force_real:
         return True, True, {"mock": True, "available_balance": 100000}, None
 
-    from integrations.delta_exchange.hmac_auth import build_auth_headers, DELTA_EXCHANGE_BASE_URL
-
+    from integrations.delta_exchange.hmac_auth import build_auth_headers, base_url_for_provider
+    base = base_url_for_provider(exchange_provider)
     balances_path = "/v2/wallet/balances"
     profile_path = "/v2/profile"
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
-            # Step 1 — verify read access via wallet balances (HMAC signed)
+            # Step 1 — verify read access (HMAC signed)
             balances_resp = await client.get(
-                f"{DELTA_EXCHANGE_BASE_URL}{balances_path}",
+                f"{base}{balances_path}",
                 headers=build_auth_headers(
-                    api_key=api_key,
-                    api_secret=api_secret,
-                    method="GET",
-                    path=balances_path,
+                    api_key=api_key, api_secret=api_secret,
+                    method="GET", path=balances_path,
                 ),
             )
             if balances_resp.status_code == 401:
-                return False, False, {}, "Invalid API key or secret"
+                err_code = balances_resp.json().get("error", {}).get("code", "unknown")
+                logger.error("validate_exchange: 401 from %s error_code=%s", base, err_code)
+                return False, False, {}, (
+                    f"Invalid credentials (code={err_code}). "
+                    f"Ensure your key belongs to {exchange_provider} (→ {base})."
+                )
             if balances_resp.status_code == 403:
                 return False, False, {}, "API key lacks read permission"
             balances_resp.raise_for_status()
@@ -207,19 +210,14 @@ async def _validate_exchange_live(
 
             # Step 2 — verify the key is active
             profile_resp = await client.get(
-                f"{DELTA_EXCHANGE_BASE_URL}{profile_path}",
+                f"{base}{profile_path}",
                 headers=build_auth_headers(
-                    api_key=api_key,
-                    api_secret=api_secret,
-                    method="GET",
-                    path=profile_path,
+                    api_key=api_key, api_secret=api_secret,
+                    method="GET", path=profile_path,
                 ),
             )
             tradeable = profile_resp.status_code == 200
-
             return True, tradeable, {"balances_count": len(balances)}, None
     except Exception as exc:
-        logger.error(
-            "validate_exchange: check failed — %s", type(exc).__name__
-        )  # no key in log
+        logger.error("validate_exchange: check failed — %s", type(exc).__name__)
         return False, False, {}, str(type(exc).__name__)

--- a/src/Plant/BackEnd/api/v1/trading_setup.py
+++ b/src/Plant/BackEnd/api/v1/trading_setup.py
@@ -63,9 +63,12 @@ async def _validate_instrument_live(instrument: str) -> bool:
     force_real = os.environ.get("DELTA_EXCHANGE_REAL_API", "").lower() == "true"
     if env in mock_envs and not force_real:
         return True  # mock: avoids network calls in dev/test
+    # Use Delta Exchange India URL — instruments endpoint is public (no HMAC needed).
+    from integrations.delta_exchange.hmac_auth import base_url_for_provider
+    base = base_url_for_provider("delta_exchange_india")
     async with httpx.AsyncClient(timeout=5.0) as client:
         resp = await client.get(
-            "https://api.delta.exchange/v2/products",
+            f"{base}/v2/products",
             params={"page_size": 100},
         )
         resp.raise_for_status()
@@ -330,8 +333,10 @@ async def _process_step(
             # Auto-advance to validation immediately
             api_key = _decrypt(collected["encrypted_api_key"])
             api_secret = _decrypt(collected["encrypted_api_secret"])
+            # Always use delta_exchange_india — the only supported provider in the wizard.
             readable, tradeable, _, error = await _validate_exchange_live(
-                api_key=api_key, api_secret=api_secret
+                api_key=api_key, api_secret=api_secret,
+                exchange_provider="delta_exchange_india",
             )
             if readable:
                 state.validation_status = "valid"

--- a/src/Plant/BackEnd/delta_exchange_pump.py
+++ b/src/Plant/BackEnd/delta_exchange_pump.py
@@ -60,10 +60,12 @@ class DeltaExchangePump(BaseComponent):
 
     @circuit_breaker(service="delta_exchange_api")
     async def _fetch_candles(self, instrument: str, api_key: str) -> list[dict]:
-        """Fetch last 50 1m candles. API key is never logged."""
+        """Fetch last 50 1m candles from Delta Exchange India. API key is never logged."""
+        from integrations.delta_exchange.hmac_auth import base_url_for_provider
+        base = base_url_for_provider("delta_exchange_india")
         async with httpx.AsyncClient() as client:
             resp = await client.get(
-                "https://api.delta.exchange/v2/history/candles",
+                f"{base}/v2/history/candles",
                 params={"symbol": instrument, "resolution": "1m", "limit": 50},
                 headers={"api-key": api_key},
                 timeout=10.0,
@@ -89,11 +91,13 @@ class DeltaExchangePump(BaseComponent):
         if env in mock_envs and not force_real:
             return []  # mock — no network call in dev/test
 
-        from integrations.delta_exchange.hmac_auth import build_auth_headers, DELTA_EXCHANGE_BASE_URL
+        from integrations.delta_exchange.hmac_auth import build_auth_headers, base_url_for_provider
+        # Provider is always delta_exchange_india — only supported platform in the wizard.
         path = "/v2/positions/margined"
+        base = base_url_for_provider("delta_exchange_india")
         async with httpx.AsyncClient(timeout=5.0) as client:
             resp = await client.get(
-                f"{DELTA_EXCHANGE_BASE_URL}{path}",
+                f"{base}{path}",
                 headers=build_auth_headers(
                     api_key=api_key,
                     api_secret=api_secret,

--- a/src/Plant/BackEnd/integrations/delta_exchange/hmac_auth.py
+++ b/src/Plant/BackEnd/integrations/delta_exchange/hmac_auth.py
@@ -22,9 +22,22 @@ import hmac
 import time
 from typing import Dict
 
-# Public base URL for Delta Exchange (international).
-# India-specific traffic also routes through this endpoint.
-DELTA_EXCHANGE_BASE_URL = "https://api.delta.exchange"
+# Public base URLs for Delta Exchange.
+# These are SEPARATE platforms with separate accounts — a key from one
+# will NOT work on the other.
+DELTA_EXCHANGE_BASE_URL = "https://api.delta.exchange"          # International (crypto futures)
+DELTA_EXCHANGE_INDIA_BASE_URL = "https://api.india.delta.exchange"  # India platform
+
+# Provider-string → base URL mapping.  Add new providers here as needed.
+PROVIDER_BASE_URL: dict[str, str] = {
+    "delta_exchange_india": DELTA_EXCHANGE_INDIA_BASE_URL,
+    "delta_exchange": DELTA_EXCHANGE_BASE_URL,
+}
+
+
+def base_url_for_provider(exchange_provider: str) -> str:
+    """Return the correct base URL for a given exchange_provider string."""
+    return PROVIDER_BASE_URL.get(exchange_provider, DELTA_EXCHANGE_INDIA_BASE_URL)
 
 
 def build_auth_headers(

--- a/src/Plant/BackEnd/tests/unit/test_delta_hmac_auth.py
+++ b/src/Plant/BackEnd/tests/unit/test_delta_hmac_auth.py
@@ -103,8 +103,19 @@ def test_method_case_normalised():
 
 
 def test_base_url_constant():
-    """T7: DELTA_EXCHANGE_BASE_URL points to the correct endpoint."""
-    from integrations.delta_exchange.hmac_auth import DELTA_EXCHANGE_BASE_URL
-
+    """T7: DELTA_EXCHANGE_BASE_URL and DELTA_EXCHANGE_INDIA_BASE_URL are correct."""
+    from integrations.delta_exchange.hmac_auth import (
+        DELTA_EXCHANGE_BASE_URL,
+        DELTA_EXCHANGE_INDIA_BASE_URL,
+        base_url_for_provider,
+    )
     assert DELTA_EXCHANGE_BASE_URL == "https://api.delta.exchange"
+    assert DELTA_EXCHANGE_INDIA_BASE_URL == "https://api.india.delta.exchange"
     assert not DELTA_EXCHANGE_BASE_URL.endswith("/")
+    assert not DELTA_EXCHANGE_INDIA_BASE_URL.endswith("/")
+
+    # Provider routing
+    assert base_url_for_provider("delta_exchange_india") == DELTA_EXCHANGE_INDIA_BASE_URL
+    assert base_url_for_provider("delta_exchange") == DELTA_EXCHANGE_BASE_URL
+    # Unknown provider defaults to India (the app is India-first)
+    assert base_url_for_provider("unknown_provider") == DELTA_EXCHANGE_INDIA_BASE_URL


### PR DESCRIPTION
## Root cause

Delta Exchange India (`api.india.delta.exchange`) and International (`api.delta.exchange`) are **completely separate platforms with separate account systems**. An India API key returns `{"error":{"code":"invalid_api_key"}}` on the international URL because the key simply doesn't exist in that system.

The previous code hard-coded `api.delta.exchange` (international) for all calls, but `exchange_provider = "delta_exchange_india"` is the default in `ExchangeCredentialModel` — so every real credential validation was hitting the wrong endpoint.

## Changes

### `integrations/delta_exchange/hmac_auth.py`
- Added `DELTA_EXCHANGE_INDIA_BASE_URL = "https://api.india.delta.exchange"`
- Added `PROVIDER_BASE_URL` dict mapping provider strings → base URLs
- Added `base_url_for_provider(exchange_provider)` helper (defaults to India for unknown providers)

### `api/v1/exchange_credentials._validate_exchange_live`
- New `exchange_provider` parameter (default `"delta_exchange_india"`)
- Selects base URL via `base_url_for_provider()`
- Logs Delta Exchange `error_code` from the 401 response body for easier debugging

### `api/v1/trading_setup.py` (validate step)
- Passes `exchange_provider="delta_exchange_india"` explicitly

### `delta_exchange_pump.py`
- `_fetch_candles` and `_fetch_open_positions` both route through `base_url_for_provider("delta_exchange_india")`

### `_validate_instrument_live`
- Uses India URL for the public `/v2/products` products endpoint

## Verified
- Local test against both endpoints with fake key confirms: signing format is correct, `invalid_api_key` error means the key doesn't exist on that platform (not a signature issue)
- 20 unit tests pass