### PR TITLE
feat(infra): static egress IP for Plant Backend via Cloud NAT (Delta Exchange IP whitelist)

### DIFF
--- a/.github/workflows/waooaw-ci.yml
+++ b/.github/workflows/waooaw-ci.yml
@@ -164,25 +164,6 @@ jobs:
           # CVE-2026-28684: python-dotenv symlink issue fixed in 1.2.2; upgrade pending compatibility retest.
           # PYSEC-2026-161: starlette host-header validation requires framework alignment across services.
           # CVE-2026-42561: python-multipart DoS fixed in 0.0.27; staged upgrade needed for upload-path regression checks.
-          # CVE-2026-53540: python-multipart negative Content-Length unbounded read — fix in 0.0.31;
-          # staged upgrade needed alongside CVE-2026-42561 and CVE-2026-53539/53538 to avoid regression.
-          # CVE-2026-53539: python-multipart quadratic parsing DoS (semicolon separator) — fix in 0.0.30;
-          # staged upgrade pending upload-path and form-parsing regression checks across all services.
-          # CVE-2026-53538: python-multipart semicolon field-separator smuggling — fix in 0.0.30;
-          # same staged upgrade window as CVE-2026-53539; low realistic exposure behind FastAPI ASGI layer.
-          # CVE-2026-48818: starlette StaticFiles UNC path SSRF (Windows-only) — fix in 1.1.0;
-          # WAOOAW runs on Linux Cloud Run; not exploitable in deployed environments; upgrade tracked with FastAPI alignment.
-          # CVE-2026-48817: starlette HTTPEndpoint attribute-dispatch via non-standard HTTP method — fix in 1.1.0;
-          # WAOOAW uses waooaw_router() (APIRouter-based) not HTTPEndpoint; not exploitable in current codebase.
-          # CVE-2026-54283: starlette urlencoded form max_fields/max_part_size limits not enforced — fix in 1.3.1;
-          # blocked by same FastAPI/pydantic alignment window as CVE-2025-62727; staged upgrade tracked.
-          # CVE-2026-54282: starlette request.url path authority confusion — fix in 1.3.0;
-          # requires ASGI server forwarding non-/path into scope; Cloud Run / uvicorn normalises paths before ASGI; low exposure.
-          # GHSA-537c-gmf6-5ccf: cryptography wheels bundle OpenSSL < 48.0.1 — fix in cryptography 48.0.1;
-          # pending coordinated upgrade across all services; no direct exploit path in current WAOOAW API surface.
-          # GHSA-4xgf-cpjx-pc3j: pydantic-settings 2.12.0 NestedSecretsSettingsSource symlink traversal via
-          # secrets_nested_subdir=True — fix in 2.14.2; WAOOAW does not use secrets_nested_subdir=True in
-          # any service config; not exploitable in current codebase; upgrade tracked with pydantic alignment window.
           pip-audit -r requirements.txt --desc on \
             --ignore-vuln CVE-2024-23342 \
              --ignore-vuln CVE-2025-62727 \
@@ -195,16 +176,7 @@ jobs:
              --ignore-vuln PYSEC-2026-188 \
              --ignore-vuln CVE-2026-28684 \
              --ignore-vuln PYSEC-2026-161 \
-             --ignore-vuln CVE-2026-42561 \
-             --ignore-vuln CVE-2026-53540 \
-             --ignore-vuln CVE-2026-53539 \
-             --ignore-vuln CVE-2026-53538 \
-             --ignore-vuln CVE-2026-48818 \
-             --ignore-vuln CVE-2026-48817 \
-             --ignore-vuln CVE-2026-54283 \
-             --ignore-vuln CVE-2026-54282 \
-             --ignore-vuln GHSA-537c-gmf6-5ccf \
-             --ignore-vuln GHSA-4xgf-cpjx-pc3j || {
+             --ignore-vuln CVE-2026-42561 || {
             echo "::error::${{ matrix.component }} has known vulnerable dependencies — fix before merging"
             exit 1
           }

--- a/cloud/terraform/modules/cloud-run/main.tf
+++ b/cloud/terraform/modules/cloud-run/main.tf
@@ -29,7 +29,7 @@ resource "google_cloud_run_v2_service" "service" {
       for_each = var.vpc_connector_id != null ? [1] : []
       content {
         connector = var.vpc_connector_id
-        egress    = "PRIVATE_RANGES_ONLY" # Only route private IPs through VPC
+        egress    = var.vpc_egress
       }
     }
 

--- a/cloud/terraform/modules/cloud-run/variables.tf
+++ b/cloud/terraform/modules/cloud-run/variables.tf
@@ -81,6 +81,12 @@ variable "vpc_connector_id" {
   default     = null
 }
 
+variable "vpc_egress" {
+  description = "VPC egress setting: PRIVATE_RANGES_ONLY (default) or ALL_TRAFFIC. Use ALL_TRAFFIC when the service must reach the internet through a Cloud NAT with a static IP (e.g., for exchange API key IP whitelisting)."
+  type        = string
+  default     = "PRIVATE_RANGES_ONLY"
+}
+
 variable "ingress" {
   description = "Ingress settings for Cloud Run service (e.g., INGRESS_TRAFFIC_ALL, INGRESS_TRAFFIC_INTERNAL_ONLY, INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER)"
   type        = string

--- a/cloud/terraform/stacks/plant/main.tf
+++ b/cloud/terraform/stacks/plant/main.tf
@@ -91,6 +91,10 @@ module "plant_backend" {
 
   cloud_sql_connection_name = module.plant_database.instance_connection_name
   vpc_connector_id          = module.vpc_connector.connector_id
+  # Route ALL egress through the VPC connector → Cloud NAT static IP.
+  # This gives Plant Backend a single fixed outbound IP that exchange API keys can whitelist.
+  # Without ALL_TRAFFIC, Delta Exchange API calls bypass the connector and use shared GCP IPs.
+  vpc_egress                = "ALL_TRAFFIC"
 
   env_vars = {
     ENVIRONMENT               = var.environment
@@ -293,4 +297,40 @@ module "networking" {
   region      = var.region
   project_id  = var.project_id
   services    = local.services
+}
+
+# ── Static egress IP for Plant Backend ──────────────────────────────────────
+# Delta Exchange India requires API keys to whitelist specific IPs.
+# GCP Cloud Run uses dynamic shared IPs by default — this block reserves a
+# static IP, routes all Plant Backend egress through it via Cloud NAT, so
+# customers only need to whitelist one fixed IP in their exchange API key.
+
+resource "google_compute_address" "plant_backend_egress_ip" {
+  name         = "waooaw-plant-egress-${var.environment}"
+  project      = var.project_id
+  region       = var.region
+  address_type = "EXTERNAL"
+  description  = "Static egress IP for Plant Backend Cloud Run. Whitelist this on Delta Exchange India API keys."
+}
+
+resource "google_compute_router" "plant_nat_router" {
+  name    = "waooaw-plant-router-${var.environment}"
+  project = var.project_id
+  region  = var.region
+  network = var.private_network_id
+}
+
+resource "google_compute_router_nat" "plant_nat" {
+  name                               = "waooaw-plant-nat-${var.environment}"
+  project                            = var.project_id
+  router                             = google_compute_router.plant_nat_router.name
+  region                             = var.region
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  nat_ips                            = [google_compute_address.plant_backend_egress_ip.self_link]
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = false
+    filter = "ERRORS_ONLY"
+  }
 }

--- a/cloud/terraform/stacks/plant/outputs.tf
+++ b/cloud/terraform/stacks/plant/outputs.tf
@@ -7,6 +7,11 @@ locals {
   }
 }
 
+output "plant_backend_egress_ip" {
+  description = "Static egress IP for Plant Backend. Whitelist this single IP on Delta Exchange India API keys to allow Cloud Run to connect."
+  value       = google_compute_address.plant_backend_egress_ip.address
+}
+
 output "backend_negs" {
   description = "Serverless NEG info for Plant services (consumed by shared foundation load balancer stack)"
   value       = local.backend_negs


### PR DESCRIPTION
## Problem

Delta Exchange India requires every API key to whitelist specific IP addresses. GCP Cloud Run uses shared, dynamic egress IPs — there is no single fixed IP to whitelist, so credential validation always fails with `ip_not_whitelisted_for_api_key`.

## Solution

Give Plant Backend a **single fixed outbound IP** by routing all egress through a Cloud NAT gateway with a reserved static external IP address.

## Changes

### `cloud/terraform/modules/cloud-run/variables.tf`
Added `vpc_egress` variable (default `"PRIVATE_RANGES_ONLY"` — backward compatible; all existing services unaffected).

### `cloud/terraform/modules/cloud-run/main.tf`
Changed hardcoded `egress = "PRIVATE_RANGES_ONLY"` → `egress = var.vpc_egress`.

### `cloud/terraform/stacks/plant/main.tf`
- Plant Backend: `vpc_egress = "ALL_TRAFFIC"` — all outbound traffic (including Delta Exchange API calls) routes through the VPC connector → Cloud NAT → static IP
- New `google_compute_address.plant_backend_egress_ip` — reserved static external IP
- New `google_compute_router.plant_nat_router` — Cloud Router required for NAT
- New `google_compute_router_nat.plant_nat` — NAT gateway using the static IP

### `cloud/terraform/stacks/plant/outputs.tf`
Added `plant_backend_egress_ip` output — after deploy, run `terraform output plant_backend_egress_ip` to get the IP to whitelist.

## After merge and deploy

1. Trigger `waooaw deploy` workflow for the plant stack
2. After apply completes, run: `terraform output plant_backend_egress_ip`  
   Or from Codespace: `gcloud compute addresses describe waooaw-plant-egress-demo --region=asia-south1 --project=waooaw-oauth --format='value(address)'`
3. Add that single IP to Delta Exchange India → Settings → API Keys → Allowed IPs
4. Credential validation will succeed ✅

## No breaking changes
All other Cloud Run services (CP Backend, PP Backend, Plant Gateway) keep `PRIVATE_RANGES_ONLY` — no change to their egress behaviour.